### PR TITLE
Prepare v0.5.7 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4128,7 +4128,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkit"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -4136,6 +4136,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rust_dotenv",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/surrealkit/Cargo.toml
+++ b/crates/surrealkit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = 'surrealkit'
 description = 'Manage migrations, seeding and tests for your SurrealDB via CLI'
-version = '0.5.6'
+version = '0.5.7'
 edition = '2024'
 authors = ['Chiru Boggavarapu <chiru@foretag.co>', 'Tobie Morgan Hitchcock <tobie@surrealdb.com>']
 repository = 'https://github.com/surrealdb/surrealkit'
@@ -24,6 +24,7 @@ tokio = { version = '1.47', features = ['macros', 'rt-multi-thread', 'signal', '
 walkdir = '2.5'
 reqwest = { version = '0.12', default-features = false, features = ['json', 'rustls-tls'] }
 regex = '1'
+rustls = { version = '0.23', default-features = false, features = ['aws-lc-rs'] }
 
 [dev-dependencies]
 surrealdb = { version = '3.0.5', features = ['kv-mem'] }

--- a/crates/surrealkit/src/main.rs
+++ b/crates/surrealkit/src/main.rs
@@ -152,6 +152,8 @@ fn load_env() -> Option<DotEnv> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
 	let args = Cli::parse();
 	let env = load_env();
 	let overrides = DbOverrides {


### PR DESCRIPTION
Adds Rustls default provider for `WSS` connections (specially for SurrealDB Cloud connections).