### PR TITLE
Prepare for v0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4128,7 +4128,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkit"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4152,7 +4152,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkit-macros"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/surrealkit-macros/Cargo.toml
+++ b/crates/surrealkit-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'surrealkit-macros'
-version = '0.6.2'
+version = '0.6.3'
 edition = '2024'
 authors = ['Chiru Boggavarapu <chiru@foretag.co>', 'Tobie Morgan Hitchcock <tobie@surrealdb.com>']
 repository = 'https://github.com/surrealdb/surrealkit'

--- a/crates/surrealkit/Cargo.toml
+++ b/crates/surrealkit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = 'surrealkit'
 description = 'Manage migrations, seeding and tests for your SurrealDB via CLI'
-version = '0.6.2'
+version = '0.6.3'
 edition = '2024'
 authors = ['Chiru Boggavarapu <chiru@foretag.co>', 'Tobie Morgan Hitchcock <tobie@surrealdb.com>']
 repository = 'https://github.com/surrealdb/surrealkit'

--- a/crates/surrealkit/src/tester/actors.rs
+++ b/crates/surrealkit/src/tester/actors.rs
@@ -34,7 +34,7 @@ fn toml_to_surreal(val: toml::Value) -> surrealdb_types::Value {
 }
 
 use super::types::{ActorKind, ActorSpec};
-use crate::config::DbCfg;
+use crate::config::{AuthLevel, DbCfg};
 use crate::core::create_surreal_client;
 
 #[derive(Debug, Clone)]
@@ -64,7 +64,7 @@ pub async fn build_actor_sessions(
 ) -> Result<HashMap<String, ActorSession>> {
 	let mut out = HashMap::new();
 
-	let root = build_default_root_session(cfg, host, namespace, database).await?;
+	let root = build_default_bootstrap_session(cfg, host, namespace, database).await?;
 	out.insert("root".to_string(), root);
 
 	for (name, spec) in specs {
@@ -75,7 +75,7 @@ pub async fn build_actor_sessions(
 	Ok(out)
 }
 
-async fn build_default_root_session(
+async fn build_default_bootstrap_session(
 	cfg: &DbCfg,
 	host: &str,
 	namespace: &str,
@@ -83,18 +83,35 @@ async fn build_default_root_session(
 ) -> Result<ActorSession> {
 	let db = create_surreal_client(&host.to_string())
 		.await
-		.with_context(|| format!("connecting root actor to {host}"))?;
-	let _token = db
-		.signin(Root {
-			username: cfg.user().to_string(),
-			password: cfg.pass().to_string(),
-		})
-		.await
-		.context("root signin failed")?;
-	db.use_ns(namespace)
-		.use_db(database)
-		.await
-		.with_context(|| format!("switching root actor to ns={namespace} db={database}"))?;
+		.with_context(|| format!("connecting bootstrap actor to {host}"))?;
+	match cfg.auth_level() {
+		AuthLevel::Root => {
+			db.signin(Root {
+				username: cfg.user().to_string(),
+				password: cfg.pass().to_string(),
+			})
+			.await
+			.context("bootstrap signin failed (auth_level=root)")?;
+			db.use_ns(namespace).use_db(database).await.with_context(|| {
+				format!("switching bootstrap actor to ns={namespace} db={database}")
+			})?;
+		}
+		AuthLevel::Namespace => {
+			db.signin(Namespace {
+				namespace: namespace.to_string(),
+				username: cfg.user().to_string(),
+				password: cfg.pass().to_string(),
+			})
+			.await
+			.context("bootstrap signin failed (auth_level=namespace)")?;
+			db.use_db(database)
+				.await
+				.with_context(|| format!("switching bootstrap actor to db={database}"))?;
+		}
+		AuthLevel::Database => {
+			unreachable!("AuthLevel::Database is rejected by tester::run_test before reaching here")
+		}
+	}
 
 	Ok(ActorSession {
 		auth: fetch_auth(&db).await?,

--- a/crates/surrealkit/src/tester/mod.rs
+++ b/crates/surrealkit/src/tester/mod.rs
@@ -13,7 +13,7 @@ use anyhow::{Result, bail};
 use rust_dotenv::dotenv::DotEnv;
 pub use types::TestOpts;
 
-use crate::config::{DbCfg, DbOverrides};
+use crate::config::{AuthLevel, DbCfg, DbOverrides};
 use crate::variables::TemplateVars;
 
 pub async fn run_test(
@@ -23,6 +23,12 @@ pub async fn run_test(
 	overrides: &DbOverrides,
 ) -> Result<()> {
 	let cfg = DbCfg::from_env(dotenv, overrides)?;
+	if matches!(cfg.auth_level(), AuthLevel::Database) {
+		bail!(
+			"`surrealkit test` requires auth level 'root' or 'namespace'/'ns'; got 'database'. \
+			 Database-scoped users cannot create the per-suite database needed for test isolation."
+		);
+	}
 	let loaded = loader::load_specs()?;
 	let filter_input = types::FilterInput {
 		suite_pattern: opts.suite.clone(),

--- a/crates/surrealkit/src/tester/runner.rs
+++ b/crates/surrealkit/src/tester/runner.rs
@@ -22,7 +22,7 @@ use super::types::{
 	AssertionReport, CaseKind, CaseReport, FilterInput, GlobalTestConfig, JsonAssertionSpec,
 	LoadedSuite, PermissionAction, RunReport, SuiteReport, TestOpts,
 };
-use crate::config::DbCfg;
+use crate::config::{AuthLevel, DbCfg};
 use crate::core::create_surreal_client;
 use crate::seed;
 use crate::setup::run_setup;
@@ -160,8 +160,19 @@ impl RunnerContext {
 		let suite_name =
 			suite.spec.name.clone().unwrap_or_else(|| suite.path.to_string_lossy().to_string());
 		let slug = slugify(&format!("{}-{}", suite_name, suite.path.display()));
-		let namespace = format!("{}_sk_test_{}_{}", self.cfg.ns(), self.run_id, slug);
-		let database = format!("{}_sk_test_{}_{}", self.cfg.db(), self.run_id, slug);
+		let (namespace, database) = match self.cfg.auth_level() {
+			AuthLevel::Root => (
+				format!("{}_sk_test_{}_{}", self.cfg.ns(), self.run_id, slug),
+				format!("{}_sk_test_{}_{}", self.cfg.db(), self.run_id, slug),
+			),
+			AuthLevel::Namespace => (
+				self.cfg.ns().to_string(),
+				format!("{}_sk_test_{}_{}", self.cfg.db(), self.run_id, slug),
+			),
+			AuthLevel::Database => {
+				unreachable!("AuthLevel::Database is rejected by tester::run_test")
+			}
+		};
 		let host = self.cfg.host().to_string();
 
 		let actors = self.prepare_suite(&suite, &host, &namespace, &database).await?;
@@ -660,19 +671,38 @@ async fn cleanup_suite_db(cfg: &DbCfg, host: &str, namespace: &str, database: &s
 	let db = create_surreal_client(&host.to_string())
 		.await
 		.with_context(|| format!("connecting for cleanup {host}"))?;
-	db.signin(surrealdb::opt::auth::Root {
-		username: cfg.user().to_string(),
-		password: cfg.pass().to_string(),
-	})
-	.await
-	.context("cleanup root signin failed")?;
-	db.use_ns(namespace).await?;
-	let drop_db = format!("REMOVE DATABASE IF EXISTS {};", database);
-	let resp = db.query(drop_db).await?;
-	let _ = resp.check();
-	let drop_ns = format!("REMOVE NAMESPACE IF EXISTS {};", namespace);
-	let resp = db.query(drop_ns).await?;
-	let _ = resp.check();
+	match cfg.auth_level() {
+		AuthLevel::Root => {
+			db.signin(surrealdb::opt::auth::Root {
+				username: cfg.user().to_string(),
+				password: cfg.pass().to_string(),
+			})
+			.await
+			.context("cleanup signin failed (auth_level=root)")?;
+			db.use_ns(namespace).await?;
+			let drop_db = format!("REMOVE DATABASE IF EXISTS {};", database);
+			let resp = db.query(drop_db).await?;
+			let _ = resp.check();
+			let drop_ns = format!("REMOVE NAMESPACE IF EXISTS {};", namespace);
+			let resp = db.query(drop_ns).await?;
+			let _ = resp.check();
+		}
+		AuthLevel::Namespace => {
+			db.signin(surrealdb::opt::auth::Namespace {
+				namespace: namespace.to_string(),
+				username: cfg.user().to_string(),
+				password: cfg.pass().to_string(),
+			})
+			.await
+			.context("cleanup signin failed (auth_level=namespace)")?;
+			let drop_db = format!("REMOVE DATABASE IF EXISTS {};", database);
+			let resp = db.query(drop_db).await?;
+			let _ = resp.check();
+		}
+		AuthLevel::Database => {
+			unreachable!("AuthLevel::Database is rejected by tester::run_test")
+		}
+	}
 	Ok(())
 }
 

--- a/crates/surrealkit/tests/auth_levels.rs
+++ b/crates/surrealkit/tests/auth_levels.rs
@@ -264,9 +264,6 @@ async fn test_runner_rejects_database_auth_level() {
 		.await
 		.expect_err("expected database auth level to be rejected");
 	let msg = err.to_string();
-	assert!(
-		msg.contains("auth level 'root' or 'namespace'"),
-		"unexpected error message: {msg}"
-	);
+	assert!(msg.contains("auth level 'root' or 'namespace'"), "unexpected error message: {msg}");
 	assert!(msg.contains("got 'database'"), "unexpected error message: {msg}");
 }

--- a/crates/surrealkit/tests/auth_levels.rs
+++ b/crates/surrealkit/tests/auth_levels.rs
@@ -18,6 +18,8 @@ use surrealdb::opt::auth::Root;
 use surrealdb::opt::capabilities::Capabilities;
 use surrealkit::config::{AuthLevel, DbCfg, DbOverrides};
 use surrealkit::connect;
+use surrealkit::tester::{TestOpts, run_test};
+use surrealkit::variables::TemplateVars;
 
 /// Serialises tests that mutate SURREALDB_AUTH_LEVEL / DATABASE_AUTH_LEVEL.
 static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -233,4 +235,38 @@ async fn connect_database_auth_wrong_password_fails() {
 		msg.contains("signin") || msg.contains("auth") || msg.contains("invalid"),
 		"unexpected error: {err}"
 	);
+}
+
+#[tokio::test]
+async fn test_runner_rejects_database_auth_level() {
+	let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+	unsafe { std::env::remove_var("SURREALDB_AUTH_LEVEL") };
+	unsafe { std::env::remove_var("DATABASE_AUTH_LEVEL") };
+	let overrides = DbOverrides {
+		auth_level: Some("database".into()),
+		..Default::default()
+	};
+	let opts = TestOpts {
+		suite: None,
+		case: None,
+		tags: Vec::new(),
+		fail_fast: false,
+		parallel: 1,
+		json_out: None,
+		no_setup: true,
+		no_sync: true,
+		no_seed: true,
+		base_url: None,
+		timeout_ms: None,
+		keep_db: false,
+	};
+	let err = run_test(None, opts, TemplateVars::default(), &overrides)
+		.await
+		.expect_err("expected database auth level to be rejected");
+	let msg = err.to_string();
+	assert!(
+		msg.contains("auth level 'root' or 'namespace'"),
+		"unexpected error message: {msg}"
+	);
+	assert!(msg.contains("got 'database'"), "unexpected error message: {msg}");
 }


### PR DESCRIPTION
Prepare for a v0.6.3 release, adds:

- Namespace level test isolation for namespace users
- Bump version to v0.6.3