### PR TITLE
feat: allow to run any statement with sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,7 +3473,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4144,6 +4144,7 @@ dependencies = [
  "surrealdb-types",
  "surrealkit-macros",
  "tempfile",
+ "test-case",
  "time",
  "tokio",
  "toml",
@@ -4254,7 +4255,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4266,6 +4267,39 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "test-case-core",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ If managed destructive prune is enabled against a shared DB, SurrealKit requires
 surrealkit sync --allow-shared-prune
 ```
 
+To allow non-`DEFINE` statements (e.g. `INSERT`, `UPDATE`, `CREATE`) in schema files:
+
+```sh
+surrealkit sync --allow-all-statements
+```
+
 `surrealkit sync` is the local/dev reconciliation path. `surrealkit rollout ...` is the shared/prod migration path.
 
 ### Recovering a stuck rollout

--- a/crates/surrealkit/Cargo.toml
+++ b/crates/surrealkit/Cargo.toml
@@ -30,6 +30,7 @@ rustls = { version = '0.23', default-features = false, features = ['aws-lc-rs'] 
 [dev-dependencies]
 surrealdb = { version = '3.0.5', features = ['kv-mem'] }
 tempfile = '3'
+test-case = "3"
 
 [lints]
 workspace = true

--- a/crates/surrealkit/src/main.rs
+++ b/crates/surrealkit/src/main.rs
@@ -71,6 +71,10 @@ enum Commands {
 		no_prune: bool,
 		#[arg(long)]
 		allow_shared_prune: bool,
+		/// Allow non-DEFINE statements in schema files (e.g. INSERT, UPDATE, CREATE).
+		/// Disables catalog entity tracking; only file-level hashes are tracked.
+		#[arg(long)]
+		allow_all_statements: bool,
 	},
 	Rollout {
 		#[command(subcommand)]
@@ -190,6 +194,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 			fail_fast,
 			no_prune,
 			allow_shared_prune,
+			allow_all_statements,
 		} => {
 			let db = connect(&cfg).await?;
 			sync::run_sync(
@@ -202,6 +207,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 					fail_fast,
 					prune: !no_prune,
 					allow_shared_prune,
+					allow_all_statements,
 					vars: template_vars,
 					folder: folder.clone(),
 				},

--- a/crates/surrealkit/src/rollout.rs
+++ b/crates/surrealkit/src/rollout.rs
@@ -139,7 +139,7 @@ pub async fn run_baseline(db: &Surreal<Any>, folder: &str) -> Result<()> {
 
 	let files = collect_schema_files(folder)?;
 	let schema_snapshot = snapshot_from_files(&files);
-	let catalog_snapshot = build_catalog_snapshot(&files)?;
+	let catalog_snapshot = build_catalog_snapshot(&files, false)?;
 
 	replace_managed_entities(db, &catalog_snapshot.entities, None, "active").await?;
 	replace_sync_hashes(db, &files).await?;
@@ -160,7 +160,7 @@ pub async fn run_plan(folder: &str, opts: RolloutPlanOpts) -> Result<()> {
 	let old_schema = load_schema_snapshot(folder)?;
 	let old_catalog = load_catalog_snapshot(folder)?;
 	let new_schema = snapshot_from_files(&files);
-	let new_catalog = build_catalog_snapshot(&files)?;
+	let new_catalog = build_catalog_snapshot(&files, false)?;
 	let file_diff = diff_schema(&old_schema, &new_schema);
 	let catalog_diff = diff_catalog(&old_catalog, &new_catalog);
 
@@ -302,11 +302,12 @@ pub async fn run_start(
 			target_hash
 		);
 	}
-	let target_catalog = build_catalog_snapshot(&files)?;
+	let target_catalog = build_catalog_snapshot(&files, false)?;
 	let source_entities = load_managed_entities(db).await?;
 	let source_catalog = CatalogSnapshot {
 		version: 2,
 		entities: source_entities.into_iter().map(|r| r.entity).collect(),
+		operations: Vec::new(),
 	};
 	start_inner(db, &rollout, &source_catalog, &target_catalog, vars).await
 }
@@ -343,11 +344,12 @@ pub async fn run_start_with_spec(
 			);
 		}
 	}
-	let target_catalog = build_catalog_snapshot(&schema_files)?;
+	let target_catalog = build_catalog_snapshot(&schema_files, false)?;
 	let source_entities = load_managed_entities(db).await?;
 	let source_catalog = CatalogSnapshot {
 		version: 2,
 		entities: source_entities.into_iter().map(|r| r.entity).collect(),
+		operations: Vec::new(),
 	};
 	start_inner(db, &make_loaded_spec(spec), &source_catalog, &target_catalog, vars).await
 }

--- a/crates/surrealkit/src/schema_state.rs
+++ b/crates/surrealkit/src/schema_state.rs
@@ -34,6 +34,8 @@ pub struct SchemaSnapshotEntry {
 pub struct CatalogSnapshot {
 	pub version: u32,
 	pub entities: Vec<CatalogEntity>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub operations: Vec<Operation>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -81,6 +83,14 @@ impl CatalogEntity {
 			name: self.name.clone(),
 		}
 	}
+}
+
+/// A non-DEFINE SQL statement collected from a schema file when
+/// `allow_all_statements` is enabled (e.g. INSERT, UPDATE, CREATE).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Operation {
+	pub sql: String,
+	pub source_path: String,
 }
 
 pub fn ensure_local_state_dirs(folder: &str) -> Result<()> {
@@ -161,6 +171,7 @@ pub fn load_catalog_snapshot(folder: &str) -> Result<CatalogSnapshot> {
 		CatalogSnapshot {
 			version: 2,
 			entities: Vec::new(),
+			operations: Vec::new(),
 		},
 	)
 }
@@ -200,23 +211,40 @@ pub fn diff_schema(old: &SchemaSnapshot, new: &SchemaSnapshot) -> FileDiff {
 	}
 }
 
-pub fn build_catalog_snapshot(files: &[SchemaFile]) -> Result<CatalogSnapshot> {
+pub fn build_catalog_snapshot(
+	files: &[SchemaFile],
+	allow_all_statements: bool,
+) -> Result<CatalogSnapshot> {
 	let mut entities = BTreeSet::new();
+	let mut operations = Vec::new();
 	for file in files {
-		let statements = parse_schema_statements(file)?;
-		for entity in statements {
+		let (file_entities, file_ops) = parse_schema_statements(file, allow_all_statements)?;
+		for entity in file_entities {
 			entities.insert(entity);
 		}
+		operations.extend(file_ops);
 	}
 
 	Ok(CatalogSnapshot {
 		version: 2,
 		entities: entities.into_iter().collect(),
+		operations,
 	})
 }
 
-pub fn parse_schema_statements(file: &SchemaFile) -> Result<Vec<CatalogEntity>> {
+/// Parse statements from a schema file.
+///
+/// Returns a tuple of `(entities, operations)`:
+/// - `entities`: catalog entities extracted from `DEFINE` statements
+/// - `operations`: raw SQL strings for non-`DEFINE` statements (only populated
+///   when `allow_all_statements` is `true`; otherwise any non-`DEFINE` statement
+///   is a hard error)
+pub fn parse_schema_statements(
+	file: &SchemaFile,
+	allow_all_statements: bool,
+) -> Result<(Vec<CatalogEntity>, Vec<Operation>)> {
 	let mut entities = Vec::new();
+	let mut operations = Vec::new();
 	for stmt in split_statements(&strip_comments(&file.sql)) {
 		let normalized = stmt.trim();
 		if normalized.is_empty() {
@@ -233,6 +261,13 @@ pub fn parse_schema_statements(file: &SchemaFile) -> Result<Vec<CatalogEntity>> 
 			continue;
 		}
 		if !upper.starts_with("DEFINE ") {
+			if allow_all_statements {
+				operations.push(Operation {
+					sql: normalized.to_string(),
+					source_path: file.path.clone(),
+				});
+				continue;
+			}
 			bail!(
 				"schema file '{}' contains a non-DEFINE statement: '{}'",
 				file.path,
@@ -259,7 +294,7 @@ sync runs inside an already-selected namespace/database. Provision these out-of-
 		entity.statement_hash = sha256_hex(normalize_statement(normalized).as_bytes());
 		entities.push(entity);
 	}
-	Ok(entities)
+	Ok((entities, operations))
 }
 
 pub fn catalog_snapshot_to_map(snapshot: &CatalogSnapshot) -> BTreeMap<EntityKey, CatalogEntity> {
@@ -680,6 +715,7 @@ fn truncate_stmt(stmt: &str) -> String {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use test_case::test_case;
 
 	#[test]
 	fn schema_diff_detects_added_modified_removed() {
@@ -739,7 +775,7 @@ mod tests {
 			.to_string(),
 		}];
 
-		let catalog = build_catalog_snapshot(&files).expect("catalog build");
+		let catalog = build_catalog_snapshot(&files, false).expect("catalog build");
 		assert!(catalog.entities.contains(&CatalogEntity {
 			kind: "table".to_string(),
 			scope: None,
@@ -769,21 +805,20 @@ mod tests {
 		);
 	}
 
-	#[test]
-	fn schema_rejects_define_namespace_and_database() {
-		for stmt in ["DEFINE NAMESPACE prod;", "DEFINE DATABASE prod;"] {
-			let file = SchemaFile {
-				path: "database/schema/root.surql".to_string(),
-				hash: "x".to_string(),
-				sql: stmt.to_string(),
-			};
-			let err = parse_schema_statements(&file)
-				.expect_err("DEFINE NAMESPACE/DATABASE must be rejected");
-			assert!(
-				err.to_string().contains("DEFINE NAMESPACE/DATABASE"),
-				"unexpected error for {stmt}: {err}"
-			);
-		}
+	#[test_case("DEFINE NAMESPACE prod;")]
+	#[test_case("DEFINE DATABASE prod;")]
+	fn schema_rejects_define_namespace_and_database(stmt: &str) {
+		let file = SchemaFile {
+			path: "database/schema/root.surql".to_string(),
+			hash: "x".to_string(),
+			sql: stmt.to_string(),
+		};
+		let err = parse_schema_statements(&file, false)
+			.expect_err("DEFINE NAMESPACE/DATABASE must be rejected");
+		assert!(
+			err.to_string().contains("DEFINE NAMESPACE/DATABASE"),
+			"unexpected error for {stmt}: {err}"
+		);
 	}
 
 	#[test]
@@ -934,16 +969,78 @@ mod tests {
 		assert_eq!(out.len(), entities.len(), "every kind should produce a stmt");
 	}
 
-	#[test]
-	fn schema_rejects_non_define_sql() {
+	#[test_case("CREATE person SET name = 'a';")]
+	#[test_case("INSERT INTO person (name) VALUES ('Alice');")]
+	#[test_case("UPDATE person SET name = 'Bob';")]
+	#[test_case("DELETE FROM person WHERE name = 'Bob';")]
+	#[test_case("SELECT * FROM person;")]
+	fn schema_rejects_non_define_sql(stmt: &str) {
 		let file = SchemaFile {
 			path: "database/schema/root.surql".to_string(),
 			hash: "x".to_string(),
-			sql: "CREATE person SET name = 'a';".to_string(),
+			sql: stmt.to_string(),
 		};
+		let err = parse_schema_statements(&file, false)
+			.expect_err(&format!("must reject non-DEFINE: {stmt}"));
+		assert!(err.to_string().contains("non-DEFINE"), "unexpected error for {stmt}: {err}");
+	}
 
-		let err = parse_schema_statements(&file).expect_err("must reject create");
-		assert!(err.to_string().contains("non-DEFINE"));
+	#[test]
+	fn ensure_overwrite_passes_through_non_define_statements() {
+		// When --allow-all-statements is used, schema files may contain INSERT/UPDATE/etc.
+		// ensure_overwrite must pass these through unchanged (no OVERWRITE injection).
+		let sql = "DEFINE TABLE person SCHEMAFULL;\n\
+		           INSERT INTO person (name) VALUES ('seed');";
+		let result = ensure_overwrite(sql);
+		assert!(result.contains("DEFINE TABLE OVERWRITE person SCHEMAFULL;"));
+		assert!(result.contains("INSERT INTO person (name) VALUES ('seed');"));
+	}
+
+	#[test_case("CREATE person SET name = 'a';")]
+	#[test_case("INSERT INTO person (name) VALUES ('Alice');")]
+	#[test_case("UPDATE person SET name = 'Bob';")]
+	#[test_case("DELETE FROM person WHERE name = 'Bob';")]
+	#[test_case("SELECT * FROM person;")]
+	fn allow_all_statements_collects_non_define_as_operations(stmt: &str) {
+		let file = SchemaFile {
+			path: "database/schema/root.surql".to_string(),
+			hash: "x".to_string(),
+			sql: stmt.to_string(),
+		};
+		let (entities, ops) = parse_schema_statements(&file, true)
+			.expect(&format!("allow_all_statements should not fail for: {stmt}"));
+		assert!(entities.is_empty(), "no catalog entity expected for: {stmt}");
+		assert_eq!(ops.len(), 1, "expected one operation for: {stmt}");
+		assert_eq!(ops[0].source_path, "database/schema/root.surql");
+	}
+
+	#[test]
+	fn allow_all_statements_mixed_define_and_operations() {
+		let sql = "DEFINE TABLE person SCHEMAFULL;\n\
+		           INSERT INTO person (name) VALUES ('seed');";
+		let file = SchemaFile {
+			path: "database/schema/mixed.surql".to_string(),
+			hash: "x".to_string(),
+			sql: sql.to_string(),
+		};
+		let (entities, ops) = parse_schema_statements(&file, true)
+			.expect("allow_all_statements should parse mixed file");
+		assert_eq!(entities.len(), 1);
+		assert_eq!(entities[0].kind, "table");
+		assert_eq!(ops.len(), 1);
+		assert!(ops[0].sql.contains("INSERT INTO person"));
+	}
+
+	#[test]
+	fn allow_all_statements_still_rejects_remove() {
+		let file = SchemaFile {
+			path: "database/schema/root.surql".to_string(),
+			hash: "x".to_string(),
+			sql: "REMOVE TABLE person;".to_string(),
+		};
+		let err = parse_schema_statements(&file, true)
+			.expect_err("REMOVE must still be rejected even with allow_all_statements");
+		assert!(err.to_string().contains("REMOVE statement"));
 	}
 
 	#[test]
@@ -957,7 +1054,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("inline -- comments must parse");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("inline -- comments must parse");
 		assert_eq!(entities.len(), 3);
 	}
 
@@ -972,7 +1070,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("inline // comments must parse");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("inline // comments must parse");
 		assert_eq!(entities.len(), 3);
 	}
 
@@ -986,7 +1085,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("string literal must be preserved");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("string literal must be preserved");
 		assert_eq!(entities.len(), 2);
 		assert!(entities.iter().any(|e| e.name == "note"));
 	}
@@ -1007,7 +1107,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("full-line comments must parse");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("full-line comments must parse");
 		assert_eq!(entities.len(), 3);
 	}
 
@@ -1020,8 +1121,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities =
-			parse_schema_statements(&file).expect("trailing comment without newline must parse");
+		let (entities, _ops) = parse_schema_statements(&file, false)
+			.expect("trailing comment without newline must parse");
 		assert_eq!(entities.len(), 1);
 	}
 
@@ -1036,7 +1137,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("tight inline comments must parse");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("tight inline comments must parse");
 		assert_eq!(entities.len(), 3);
 	}
 
@@ -1051,7 +1153,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("mid-statement comment must parse");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("mid-statement comment must parse");
 		assert_eq!(entities.len(), 2);
 		assert!(entities.iter().any(|e| e.name == "a"));
 	}
@@ -1069,7 +1172,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("single - and / must not be stripped");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("single - and / must not be stripped");
 		assert_eq!(entities.len(), 3);
 	}
 
@@ -1084,7 +1188,7 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file)
+		let (entities, _ops) = parse_schema_statements(&file, false)
 			.expect("comment markers inside \"...\" and `...` must be preserved");
 		assert_eq!(entities.len(), 3);
 		// The field 'b' must survive — if '--' inside backticks were stripped, the table
@@ -1103,7 +1207,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("empty comments must parse");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("empty comments must parse");
 		assert_eq!(entities.len(), 3);
 	}
 
@@ -1118,7 +1223,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("triple-dash must parse");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("triple-dash must parse");
 		assert_eq!(entities.len(), 2);
 	}
 
@@ -1135,7 +1241,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("# comments must parse");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("# comments must parse");
 		assert_eq!(entities.len(), 3);
 	}
 
@@ -1149,7 +1256,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("# inside string must be preserved");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("# inside string must be preserved");
 		assert_eq!(entities.len(), 2);
 	}
 
@@ -1164,7 +1272,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("inline block comments must parse");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("inline block comments must parse");
 		assert_eq!(entities.len(), 3);
 	}
 
@@ -1184,8 +1293,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities =
-			parse_schema_statements(&file).expect("multi-line block comments must parse");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("multi-line block comments must parse");
 		assert_eq!(entities.len(), 2);
 	}
 
@@ -1199,7 +1308,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("/* inside string must be preserved");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("/* inside string must be preserved");
 		assert_eq!(entities.len(), 2);
 	}
 
@@ -1213,7 +1323,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("unterminated block must parse");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("unterminated block must parse");
 		assert_eq!(entities.len(), 1);
 	}
 
@@ -1229,8 +1340,8 @@ mod tests {
 			sql: sql.to_string(),
 		};
 
-		let entities =
-			parse_schema_statements(&file).expect("escaped quote inside string must parse");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("escaped quote inside string must parse");
 		assert_eq!(entities.len(), 2);
 	}
 
@@ -1242,7 +1353,8 @@ mod tests {
 			sql: "LET $types = ['image/png', 'image/jpeg'];\nDEFINE TABLE OVERWRITE storage SCHEMAFULL;".to_string(),
 		};
 
-		let entities = parse_schema_statements(&file).expect("LET should be allowed");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("LET should be allowed");
 		assert_eq!(entities.len(), 1);
 		assert_eq!(entities[0].kind, "table");
 	}
@@ -1259,6 +1371,7 @@ mod tests {
 				statement_hash: "a".to_string(),
 				file_hash: "file-a".to_string(),
 			}],
+			operations: Vec::new(),
 		};
 		let new = CatalogSnapshot {
 			version: 2,
@@ -1270,6 +1383,7 @@ mod tests {
 				statement_hash: "b".to_string(),
 				file_hash: "file-b".to_string(),
 			}],
+			operations: Vec::new(),
 		};
 
 		let diff = diff_catalog(&old, &new);
@@ -1408,7 +1522,8 @@ mod tests {
 			hash: "h".to_string(),
 			sql: "DEFINE TABLE IF NOT EXISTS person SCHEMAFULL;".to_string(),
 		};
-		let entities = parse_schema_statements(&file).expect("should parse IF NOT EXISTS table");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("should parse IF NOT EXISTS table");
 		assert_eq!(entities.len(), 1);
 		assert_eq!(entities[0].kind, "table");
 		assert_eq!(entities[0].name, "person");
@@ -1422,7 +1537,8 @@ mod tests {
 			hash: "h".to_string(),
 			sql: "DEFINE FIELD IF NOT EXISTS email ON person TYPE string;".to_string(),
 		};
-		let entities = parse_schema_statements(&file).expect("should parse IF NOT EXISTS field");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("should parse IF NOT EXISTS field");
 		assert_eq!(entities.len(), 1);
 		assert_eq!(entities[0].kind, "field");
 		assert_eq!(entities[0].name, "email");
@@ -1436,7 +1552,8 @@ mod tests {
 			hash: "h".to_string(),
 			sql: "DEFINE EVENT IF NOT EXISTS changed ON person WHEN true THEN ();".to_string(),
 		};
-		let entities = parse_schema_statements(&file).expect("should parse IF NOT EXISTS event");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("should parse IF NOT EXISTS event");
 		assert_eq!(entities.len(), 1);
 		assert_eq!(entities[0].kind, "event");
 		assert_eq!(entities[0].name, "changed");
@@ -1450,7 +1567,8 @@ mod tests {
 			hash: "h".to_string(),
 			sql: "DEFINE INDEX IF NOT EXISTS by_email ON TABLE person FIELDS email;".to_string(),
 		};
-		let entities = parse_schema_statements(&file).expect("should parse IF NOT EXISTS index");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("should parse IF NOT EXISTS index");
 		assert_eq!(entities.len(), 1);
 		assert_eq!(entities[0].kind, "index");
 		assert_eq!(entities[0].name, "by_email");
@@ -1465,7 +1583,8 @@ mod tests {
 			sql: "DEFINE FUNCTION IF NOT EXISTS fn::greet($name: string) { RETURN $name; };"
 				.to_string(),
 		};
-		let entities = parse_schema_statements(&file).expect("should parse IF NOT EXISTS function");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("should parse IF NOT EXISTS function");
 		assert_eq!(entities.len(), 1);
 		assert_eq!(entities[0].kind, "function");
 		assert_eq!(entities[0].name, "fn::greet");
@@ -1478,7 +1597,8 @@ mod tests {
 			hash: "h".to_string(),
 			sql: "DEFINE PARAM IF NOT EXISTS $env VALUE 'dev';".to_string(),
 		};
-		let entities = parse_schema_statements(&file).expect("should parse IF NOT EXISTS param");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("should parse IF NOT EXISTS param");
 		assert_eq!(entities.len(), 1);
 		assert_eq!(entities[0].kind, "param");
 		assert_eq!(entities[0].name, "$env");
@@ -1491,7 +1611,8 @@ mod tests {
 			hash: "h".to_string(),
 			sql: "DEFINE ANALYZER IF NOT EXISTS english TOKENIZERS blank, class;".to_string(),
 		};
-		let entities = parse_schema_statements(&file).expect("should parse IF NOT EXISTS analyzer");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("should parse IF NOT EXISTS analyzer");
 		assert_eq!(entities.len(), 1);
 		assert_eq!(entities[0].kind, "analyzer");
 		assert_eq!(entities[0].name, "english");
@@ -1504,7 +1625,8 @@ mod tests {
 			hash: "h".to_string(),
 			sql: "DEFINE ACCESS IF NOT EXISTS admin ON DATABASE TYPE RECORD;".to_string(),
 		};
-		let entities = parse_schema_statements(&file).expect("should parse IF NOT EXISTS access");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("should parse IF NOT EXISTS access");
 		assert_eq!(entities.len(), 1);
 		assert_eq!(entities[0].kind, "access");
 		assert_eq!(entities[0].name, "admin");
@@ -1518,7 +1640,8 @@ mod tests {
 			hash: "h".to_string(),
 			sql: "DEFINE USER IF NOT EXISTS app ON DATABASE PASSHASH 'x';".to_string(),
 		};
-		let entities = parse_schema_statements(&file).expect("should parse IF NOT EXISTS user");
+		let (entities, _ops) =
+			parse_schema_statements(&file, false).expect("should parse IF NOT EXISTS user");
 		assert_eq!(entities.len(), 1);
 		assert_eq!(entities[0].kind, "user");
 		assert_eq!(entities[0].name, "app");
@@ -1544,7 +1667,8 @@ mod tests {
 			.to_string(),
 		}];
 
-		let catalog = build_catalog_snapshot(&files).expect("catalog should handle IF NOT EXISTS");
+		let catalog =
+			build_catalog_snapshot(&files, false).expect("catalog should handle IF NOT EXISTS");
 		assert_eq!(catalog.entities.len(), 9, "all 9 entity types should be extracted");
 
 		let kinds: Vec<&str> = catalog.entities.iter().map(|e| e.kind.as_str()).collect();
@@ -1576,6 +1700,7 @@ mod tests {
 				statement_hash: ine_hash,
 				file_hash: "f1".to_string(),
 			}],
+			operations: Vec::new(),
 		};
 		let new = CatalogSnapshot {
 			version: 2,
@@ -1587,6 +1712,7 @@ mod tests {
 				statement_hash: ow_hash,
 				file_hash: "f2".to_string(),
 			}],
+			operations: Vec::new(),
 		};
 
 		let diff = diff_catalog(&old, &new);

--- a/crates/surrealkit/src/sync.rs
+++ b/crates/surrealkit/src/sync.rs
@@ -29,6 +29,10 @@ pub struct SyncOpts {
 	pub fail_fast: bool,
 	pub prune: bool,
 	pub allow_shared_prune: bool,
+	/// Allow non-DEFINE statements (e.g. INSERT, UPDATE) in schema files.
+	/// When set, schema files are not parsed for catalog entity tracking;
+	/// they are applied as-is and only file-level hashes are tracked.
+	pub allow_all_statements: bool,
 	/// Template variables substituted into `.surql` content before execution.
 	pub vars: TemplateVars,
 	/// Root folder for the database directory (default: `./database`).
@@ -95,6 +99,7 @@ pub async fn run_sync_embedded(
 			fail_fast: true,
 			prune: true,
 			allow_shared_prune: false,
+			allow_all_statements: false,
 			vars: TemplateVars::default(),
 			folder: String::new(),
 		},
@@ -140,7 +145,7 @@ async fn run_sync_with_files(
 	files: &[SchemaFile],
 	watch_mode: bool,
 ) -> Result<()> {
-	let desired_catalog = build_catalog_snapshot(files)?;
+	let desired_catalog = build_catalog_snapshot(files, opts.allow_all_statements)?;
 	let tracked = load_sync_hashes(db).await?;
 	let managed = load_managed_entities(db).await?;
 
@@ -261,6 +266,37 @@ async fn run_sync_with_files(
 		} else {
 			prune_managed_entities(db, &stale_entities).await?;
 			pruned_count = stale_count;
+		}
+	}
+
+	// Run operations (non-DEFINE statements) after all entities have been applied.
+	let pending_operations: Vec<_> = desired_catalog
+		.operations
+		.iter()
+		.filter(|op| !failed_paths.contains(&op.source_path))
+		.collect();
+	if !pending_operations.is_empty() {
+		if opts.dry_run {
+			if !watch_mode {
+				println!("DRY RUN: would run {} operation(s)", pending_operations.len());
+			}
+		} else {
+			for op in &pending_operations {
+				match exec_surql(db, &op.sql).await {
+					Ok(_) => {
+						if !watch_mode {
+							println!("ran operation from {}", op.source_path);
+						}
+					}
+					Err(err) => {
+						apply_errors += 1;
+						eprintln!("error running operation from {}: {err:#}", op.source_path);
+						if opts.fail_fast {
+							return Err(err);
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/crates/surrealkit/src/tester/runner.rs
+++ b/crates/surrealkit/src/tester/runner.rs
@@ -257,6 +257,7 @@ impl RunnerContext {
 					fail_fast: true,
 					prune: true,
 					allow_shared_prune: true,
+					allow_all_statements: false,
 					vars: self.vars.clone(),
 					folder: self.cfg.folder().to_owned(),
 				},


### PR DESCRIPTION
## Changes

* Add an arg `--allow-all-statements` to allow any statement (mostly `UPSERT`) in schema changes.
* Extract `operations` from the schemas to be put in the `catalog`
* Operations are run after all entities are applied 

## Use cases

It happens that some tables in a database schema are tables that contains purely static data, a specific set of rows. This could in theory be placed in a `seed` file but it makes more sense to be colocated directly inside the schema file. See:

```surql
DEFINE TABLE point_of_interest SCHEMAFULL;

DEFINE FIELD description ON point_of_interest TYPE string;

UPSERT point_of_interest:london SET description = "Our main headquarters";
UPSERT point_of_interest:paris SET description = "A quiet place";

```

Also, when running `surrealkit sync --watch --allow-all-statements`, all statements (DEFINE and non-DEFINE) are run on any change which means less friction => a single command to run the database setup.