### PR TITLE
fix(sync): emit `REMOVE … IF EXISTS` in pruner so drift self-heals

### DIFF
--- a/crates/surrealkit/src/schema_state.rs
+++ b/crates/surrealkit/src/schema_state.rs
@@ -299,33 +299,46 @@ pub fn render_remove_sql(entities: &[EntityKey], api_supported: bool) -> Result<
 	let mut ordered = entities.to_vec();
 	ordered.sort_by_key(removal_sort_key);
 
+	// All emitted statements include `IF EXISTS` so the pruner is idempotent
+	// against catalog drift. If an entity was removed from the live DB outside
+	// of surrealkit (e.g., a `run_sql REMOVE …` rollout step that bypassed the
+	// catalog), the next sync would otherwise fail with `X does not exist` and
+	// halt — leaving the catalog and DB stuck out of sync. With `IF EXISTS` the
+	// prune succeeds, the catalog row is deleted by the surrounding code, and
+	// drift self-heals.
 	let mut out = Vec::new();
 	for entity in ordered {
 		let stmt = match entity.kind.as_str() {
-			"field" => {
-				format!("REMOVE FIELD {} ON {};", entity.name, scope_or_err(&entity, "FIELD")?)
-			}
-			"event" => {
-				format!("REMOVE EVENT {} ON {};", entity.name, scope_or_err(&entity, "EVENT")?)
-			}
-			"index" => {
-				format!("REMOVE INDEX {} ON {};", entity.name, scope_or_err(&entity, "INDEX")?)
-			}
-			"table" => format!("REMOVE TABLE {};", entity.name),
-			"function" => format!("REMOVE FUNCTION {};", entity.name),
-			"param" => format!("REMOVE PARAM {};", entity.name),
+			"field" => format!(
+				"REMOVE FIELD IF EXISTS {} ON {};",
+				entity.name,
+				scope_or_err(&entity, "FIELD")?
+			),
+			"event" => format!(
+				"REMOVE EVENT IF EXISTS {} ON {};",
+				entity.name,
+				scope_or_err(&entity, "EVENT")?
+			),
+			"index" => format!(
+				"REMOVE INDEX IF EXISTS {} ON {};",
+				entity.name,
+				scope_or_err(&entity, "INDEX")?
+			),
+			"table" => format!("REMOVE TABLE IF EXISTS {};", entity.name),
+			"function" => format!("REMOVE FUNCTION IF EXISTS {};", entity.name),
+			"param" => format!("REMOVE PARAM IF EXISTS {};", entity.name),
 			"access" => match &entity.scope {
-				Some(scope) => format!("REMOVE ACCESS {} ON {};", entity.name, scope),
-				None => format!("REMOVE ACCESS {};", entity.name),
+				Some(scope) => format!("REMOVE ACCESS IF EXISTS {} ON {};", entity.name, scope),
+				None => format!("REMOVE ACCESS IF EXISTS {};", entity.name),
 			},
-			"analyzer" => format!("REMOVE ANALYZER {};", entity.name),
+			"analyzer" => format!("REMOVE ANALYZER IF EXISTS {};", entity.name),
 			"user" => match &entity.scope {
-				Some(scope) => format!("REMOVE USER {} ON {};", entity.name, scope),
-				None => format!("REMOVE USER {};", entity.name),
+				Some(scope) => format!("REMOVE USER IF EXISTS {} ON {};", entity.name, scope),
+				None => format!("REMOVE USER IF EXISTS {};", entity.name),
 			},
 			"api" => {
 				if api_supported {
-					format!("REMOVE API {};", entity.name)
+					format!("REMOVE API IF EXISTS {};", entity.name)
 				} else {
 					bail!(
 						"API removal requested for '{}' but this SurrealDB server does not support `REMOVE API`. \
@@ -334,10 +347,10 @@ Use a manual migration or upgrade server support.",
 					);
 				}
 			}
-			"bucket" => format!("REMOVE BUCKET {};", entity.name),
-			"model" => format!("REMOVE MODEL {};", entity.name),
-			"sequence" => format!("REMOVE SEQUENCE {};", entity.name),
-			"config" => format!("REMOVE CONFIG {};", entity.name),
+			"bucket" => format!("REMOVE BUCKET IF EXISTS {};", entity.name),
+			"model" => format!("REMOVE MODEL IF EXISTS {};", entity.name),
+			"sequence" => format!("REMOVE SEQUENCE IF EXISTS {};", entity.name),
+			"config" => format!("REMOVE CONFIG IF EXISTS {};", entity.name),
 			_ => continue,
 		};
 		out.push(stmt);
@@ -794,10 +807,10 @@ mod tests {
 			},
 		];
 		let out = render_remove_sql(&entities, true).expect("remove sql");
-		assert!(out.iter().any(|l| l == "REMOVE BUCKET assets;"));
-		assert!(out.iter().any(|l| l == "REMOVE SEQUENCE order_no;"));
-		assert!(out.iter().any(|l| l == "REMOVE CONFIG GRAPHQL;"));
-		assert!(out.iter().any(|l| l == "REMOVE MODEL ml::sentiment;"));
+		assert!(out.iter().any(|l| l == "REMOVE BUCKET IF EXISTS assets;"));
+		assert!(out.iter().any(|l| l == "REMOVE SEQUENCE IF EXISTS order_no;"));
+		assert!(out.iter().any(|l| l == "REMOVE CONFIG IF EXISTS GRAPHQL;"));
+		assert!(out.iter().any(|l| l == "REMOVE MODEL IF EXISTS ml::sentiment;"));
 	}
 
 	#[test]
@@ -821,12 +834,103 @@ mod tests {
 		];
 
 		let supported = render_remove_sql(&entities, true).expect("api should be supported");
-		assert_eq!(supported[0], "REMOVE FIELD nickname ON person;");
-		assert!(supported.iter().any(|line| line == "REMOVE API v1;"));
-		assert_eq!(supported.last().expect("table removal"), "REMOVE TABLE person;");
+		assert_eq!(supported[0], "REMOVE FIELD IF EXISTS nickname ON person;");
+		assert!(supported.iter().any(|line| line == "REMOVE API IF EXISTS v1;"));
+		assert_eq!(
+			supported.last().expect("table removal"),
+			"REMOVE TABLE IF EXISTS person;"
+		);
 
 		let unsupported = render_remove_sql(&entities, false);
 		assert!(unsupported.is_err());
+	}
+
+	#[test]
+	fn render_remove_sql_emits_if_exists_for_every_kind() {
+		// Without IF EXISTS, a single missing entity would halt the whole prune
+		// batch in sync.rs::prune_managed_entities (REMOVEs are joined and
+		// executed together). Verify every kind we render carries IF EXISTS so
+		// catalog drift is self-healing.
+		let entities = vec![
+			EntityKey {
+				kind: "field".into(),
+				scope: Some("person".into()),
+				name: "nickname".into(),
+			},
+			EntityKey {
+				kind: "event".into(),
+				scope: Some("person".into()),
+				name: "audit".into(),
+			},
+			EntityKey {
+				kind: "index".into(),
+				scope: Some("person".into()),
+				name: "name_idx".into(),
+			},
+			EntityKey {
+				kind: "table".into(),
+				scope: None,
+				name: "person".into(),
+			},
+			EntityKey {
+				kind: "function".into(),
+				scope: None,
+				name: "fn::greet".into(),
+			},
+			EntityKey {
+				kind: "param".into(),
+				scope: None,
+				name: "$greeting".into(),
+			},
+			EntityKey {
+				kind: "access".into(),
+				scope: Some("DATABASE".into()),
+				name: "user_jwt".into(),
+			},
+			EntityKey {
+				kind: "analyzer".into(),
+				scope: None,
+				name: "blank".into(),
+			},
+			EntityKey {
+				kind: "user".into(),
+				scope: Some("DATABASE".into()),
+				name: "admin".into(),
+			},
+			EntityKey {
+				kind: "api".into(),
+				scope: None,
+				name: "v1".into(),
+			},
+			EntityKey {
+				kind: "bucket".into(),
+				scope: None,
+				name: "assets".into(),
+			},
+			EntityKey {
+				kind: "model".into(),
+				scope: None,
+				name: "ml::sentiment".into(),
+			},
+			EntityKey {
+				kind: "sequence".into(),
+				scope: None,
+				name: "order_no".into(),
+			},
+			EntityKey {
+				kind: "config".into(),
+				scope: None,
+				name: "GRAPHQL".into(),
+			},
+		];
+		let out = render_remove_sql(&entities, true).expect("render");
+		for stmt in &out {
+			assert!(
+				stmt.contains("IF EXISTS"),
+				"every REMOVE must include IF EXISTS so prune is idempotent against catalog drift; offending: {stmt}"
+			);
+		}
+		assert_eq!(out.len(), entities.len(), "every kind should produce a stmt");
 	}
 
 	#[test]

--- a/crates/surrealkit/src/schema_state.rs
+++ b/crates/surrealkit/src/schema_state.rs
@@ -836,10 +836,7 @@ mod tests {
 		let supported = render_remove_sql(&entities, true).expect("api should be supported");
 		assert_eq!(supported[0], "REMOVE FIELD IF EXISTS nickname ON person;");
 		assert!(supported.iter().any(|line| line == "REMOVE API IF EXISTS v1;"));
-		assert_eq!(
-			supported.last().expect("table removal"),
-			"REMOVE TABLE IF EXISTS person;"
-		);
+		assert_eq!(supported.last().expect("table removal"), "REMOVE TABLE IF EXISTS person;");
 
 		let unsupported = render_remove_sql(&entities, false);
 		assert!(unsupported.is_err());

--- a/crates/surrealkit/tests/library_api.rs
+++ b/crates/surrealkit/tests/library_api.rs
@@ -140,6 +140,58 @@ async fn sync_embedded_prunes_removed_files() {
 }
 
 #[tokio::test]
+async fn sync_embedded_self_heals_catalog_drift() {
+	// Catalog drift: an entity tracked in __entity is already missing from the
+	// live DB (e.g., a `run_sql REMOVE …` rollout step dropped it but didn't
+	// update the catalog). On the next sync, the pruner emits REMOVE for that
+	// entity. Without `IF EXISTS` the REMOVE fails with "X does not exist" and
+	// halts the whole prune batch (sync.rs::prune_managed_entities joins all
+	// statements). With `IF EXISTS` the prune succeeds and the catalog row is
+	// reaped, so drift self-heals on the next sync.
+
+	let db = mem_db().await;
+
+	static WITH_FIELD: &[EmbeddedSchemaFile] = &[EmbeddedSchemaFile {
+		path: "database/schema/drift.surql",
+		sql: "DEFINE TABLE drift_target SCHEMAFULL;\n\
+		      DEFINE FIELD nickname ON drift_target TYPE string;",
+	}];
+	run_sync_embedded(&db, WITH_FIELD).await.expect("initial sync");
+
+	// Simulate the rollout step that dropped the field by raw `run_sql`:
+	// the live DB no longer has it, but __entity still tracks it.
+	db.query("REMOVE FIELD nickname ON drift_target;")
+		.await
+		.expect("manual remove query")
+		.check()
+		.expect("manual remove succeeded");
+
+	// Drop the file entirely so the pruner is asked to remove BOTH the table
+	// (still present) AND the field (already gone). Pre-fix, the field prune
+	// errors and the table is never reached.
+	static EMPTY: &[EmbeddedSchemaFile] = &[];
+	run_sync_embedded_with_opts(
+		&db,
+		EMPTY,
+		&SyncOpts {
+			watch: false,
+			debounce_ms: 0,
+			dry_run: false,
+			fail_fast: true,
+			prune: true,
+			allow_shared_prune: false,
+			..Default::default()
+		},
+	)
+	.await
+	.expect("pruning sync should self-heal drift, not error on missing field");
+
+	let mut resp = db.query("SELECT * FROM __entity WHERE ns = 'sync';").await.expect("query");
+	let rows: Vec<serde_json::Value> = resp.take(0).expect("take");
+	assert!(rows.is_empty(), "catalog must be fully reaped: {rows:?}");
+}
+
+#[tokio::test]
 async fn sync_embedded_dry_run_makes_no_changes() {
 	let db = mem_db().await;
 


### PR DESCRIPTION
## Summary

`render_remove_sql` in `crates/surrealkit/src/schema_state.rs` produces every `REMOVE` statement that the pruner emits. `prune_managed_entities` in `sync.rs` joins them into a single batch and executes it. If any one statement targets an entity that has already been dropped from the live DB — for example by a `run_sql REMOVE …` step in a `.toml` rollout that bypassed the catalog — the bare `REMOVE` fails with `X does not exist` and **halts the entire prune batch**.

The catalog (`__entity` in the `sync` namespace) and the live DB are then stuck out of sync, and every subsequent `surrealkit sync` errors the same way. The recovery path today is manual: identify the orphans via `sync --dry-run -v`, then `DELETE __entity WHERE key IN [...]` by hand.

## Fix

Every kind that `render_remove_sql` emits now carries `IF EXISTS`:

| Kind | Before | After |
| --- | --- | --- |
| field | `REMOVE FIELD x ON t;` | `REMOVE FIELD IF EXISTS x ON t;` |
| event | `REMOVE EVENT x ON t;` | `REMOVE EVENT IF EXISTS x ON t;` |
| index | `REMOVE INDEX x ON t;` | `REMOVE INDEX IF EXISTS x ON t;` |
| table | `REMOVE TABLE x;` | `REMOVE TABLE IF EXISTS x;` |
| function | `REMOVE FUNCTION x;` | `REMOVE FUNCTION IF EXISTS x;` |
| param | `REMOVE PARAM x;` | `REMOVE PARAM IF EXISTS x;` |
| access | `REMOVE ACCESS x [ON s];` | `REMOVE ACCESS IF EXISTS x [ON s];` |
| analyzer | `REMOVE ANALYZER x;` | `REMOVE ANALYZER IF EXISTS x;` |
| user | `REMOVE USER x [ON s];` | `REMOVE USER IF EXISTS x [ON s];` |
| api | `REMOVE API x;` | `REMOVE API IF EXISTS x;` |
| bucket | `REMOVE BUCKET x;` | `REMOVE BUCKET IF EXISTS x;` |
| model | `REMOVE MODEL x;` | `REMOVE MODEL IF EXISTS x;` |
| sequence | `REMOVE SEQUENCE x;` | `REMOVE SEQUENCE IF EXISTS x;` |
| config | `REMOVE CONFIG x;` | `REMOVE CONFIG IF EXISTS x;` |

SurrealDB already treats `REMOVE … IF EXISTS` as idempotent across every form (the cleanup paths in `runner.rs` already rely on this for `REMOVE NAMESPACE/DATABASE IF EXISTS`). The prune now succeeds against missing targets, the catalog row is reaped by the surrounding `delete_managed_entities` call, and drift self-heals on the next sync.

## Tests

| Test | Purpose |
| --- | --- |
| `render_remove_sql_emits_if_exists_for_every_kind` (new unit) | Asserts every kind's rendered statement contains `IF EXISTS`, so a future kind added without `IF EXISTS` fails CI |
| `render_remove_sql_covers_new_kinds` (updated) | Existing assertions updated to the new string form |
| `render_remove_sql_respects_api_support` (updated) | Existing assertions updated to the new string form |
| `sync_embedded_self_heals_catalog_drift` (new integration) | Full end-to-end: sync a TABLE + FIELD, drop the FIELD with raw `REMOVE` (simulating a `run_sql` rollout), re-sync with no files, assert the prune succeeds and `__entity` is fully reaped. Pre-fix this errors on the missing field |

## Test plan

- [x] `cargo test -p surrealkit` (lib + integration): all binaries green, including the new tests
- [x] Patch applies cleanly against `main` (HEAD `7771b93` at time of writing)
- [x] No public API change — `render_remove_sql`'s signature is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)