### PR TITLE
feat: connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ surrealkit --host http://localhost:8000 --ns my_ns --db my_db --user root --pass
 
 | Flag           | Description                                                            | Default                 |
 | -------------- | ---------------------------------------------------------------------- | ----------------------- |
-| `--connection` | Named host/auth connection from `surrealkit.toml` or connection env (`--conn` alias) | unset                   |
+| `--connection` | Named database host/auth connection                                    | unset                   |
 | `--host`       | Database host URL                                                      | `http://localhost:8000` |
 | `--ns`         | Database namespace                                                     | `db`                    |
 | `--db`         | Database name                                                          | `test`                  |
@@ -116,7 +116,7 @@ These can be set as system environment variables or in a `.env` file.
 
 ### Connections
 
-Connections define named defaults for host/auth settings only.
+Connections define named defaults for host/auth.
 
 ```toml
 [connections.local]
@@ -126,7 +126,7 @@ pass = "root"
 auth_level = "root"
 ```
 
-With `--connection local` or `--conn local`, connection-backed fields resolve in this order:
+With `--connection local`, connection-backed fields resolve in this order:
 
 ```text
 per-field CLI > SURREALDB_CONNECTION_LOCAL_* env > .env connection values > surrealkit.toml connection > global env > .env global values > defaults

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ surrealkit init
 
 This creates a directory `/database` with the necessary scaffolding
 
-Connection details can be provided via CLI arguments, environment variables, or a `.env` file. The resolution order is: CLI args > system env vars > `.env` file > defaults.
+Connection details can be provided via CLI arguments, environment variables, a `.env` file, or named connections in `surrealkit.toml`. Without `--connection`, the resolution order is: CLI args > system env vars > `.env` file > defaults.
 
 ### CLI Arguments
 
@@ -94,6 +94,7 @@ surrealkit --host http://localhost:8000 --ns my_ns --db my_db --user root --pass
 
 | Flag           | Description                                                            | Default                 |
 | -------------- | ---------------------------------------------------------------------- | ----------------------- |
+| `--connection` | Named host/auth connection from `surrealkit.toml` or connection env (`--conn` alias) | unset                   |
 | `--host`       | Database host URL                                                      | `http://localhost:8000` |
 | `--ns`         | Database namespace                                                     | `db`                    |
 | `--db`         | Database name                                                          | `test`                  |
@@ -112,6 +113,33 @@ surrealkit --host http://localhost:8000 --ns my_ns --db my_db --user root --pass
 - `SURREALDB_FOLDER` — root folder for schema, rollouts, snapshots, seed, and tests (default: `./database`)
 
 These can be set as system environment variables or in a `.env` file.
+
+### Connections
+
+Connections define named defaults for host/auth settings only.
+
+```toml
+[connections.local]
+host = "http://localhost:8000"
+user = "root"
+pass = "root"
+auth_level = "root"
+```
+
+With `--connection local` or `--conn local`, connection-backed fields resolve in this order:
+
+```text
+per-field CLI > SURREALDB_CONNECTION_LOCAL_* env > .env connection values > surrealkit.toml connection > global env > .env global values > defaults
+```
+
+Supported connection-specific env vars are:
+
+- `SURREALDB_CONNECTION_<CONNECTION>_HOST`
+- `SURREALDB_CONNECTION_<CONNECTION>_USER`
+- `SURREALDB_CONNECTION_<CONNECTION>_PASSWORD`
+- `SURREALDB_CONNECTION_<CONNECTION>_AUTH_LEVEL`
+
+`<CONNECTION>` is uppercased and non-alphanumeric separators become `_`, so `--connection staging-us` reads `SURREALDB_CONNECTION_STAGING_US_HOST`.
 
 SurrealKit creates and manages its internal sync and rollout metadata tables on your configured database.
 

--- a/crates/surrealkit/README.md
+++ b/crates/surrealkit/README.md
@@ -200,14 +200,16 @@ seed_from_dir(&db, std::path::Path::new("fixtures/seed")).await?;
 
 ## Connecting
 
-`DbCfg` reads connection details from environment variables (with CLI-argument overrides). `connect` wraps `surrealdb::Surreal` construction and authentication:
+`Cfg` reads connection details from environment variables, optional named connections, and explicit overrides. `connect` wraps `surrealdb::Surreal` construction and authentication:
 
 ```rust
-use surrealkit::{DbCfg, DbOverrides, connect};
+use surrealkit::{Cfg, ConfigOverrides, connect};
 
-let cfg = DbCfg::from_env(None, &DbOverrides::default())?;
+let cfg = Cfg::from_env(None, &ConfigOverrides::default())?;
 let db = connect(&cfg).await?;
 ```
+
+To resolve host/auth defaults from `[connections.local]` in `surrealkit.toml` or `SURREALDB_CONNECTION_LOCAL_*` env vars, set `ConfigOverrides { connection: Some("local".into()), ..Default::default() }`.
 
 For in-process SurrealDB (e.g. `kv-mem`, `kv-rocksdb`), construct a `surrealdb::Surreal` directly and pass it to any of the library functions:
 

--- a/crates/surrealkit/src/config.rs
+++ b/crates/surrealkit/src/config.rs
@@ -1,7 +1,10 @@
+use std::collections::HashMap;
 use std::env;
+use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use rust_dotenv::dotenv::DotEnv;
+use serde::Deserialize;
 use surrealdb::Surreal;
 use surrealdb::engine::any::Any;
 use surrealdb::opt::auth::{Database, Namespace, Root};
@@ -34,6 +37,7 @@ impl AuthLevel {
 
 #[derive(Debug, Clone, Default)]
 pub struct ConfigOverrides {
+	pub connection: Option<String>,
 	pub host: Option<String>,
 	pub ns: Option<String>,
 	pub db: Option<String>,
@@ -41,6 +45,22 @@ pub struct ConfigOverrides {
 	pub pass: Option<String>,
 	pub auth_level: Option<String>,
 	pub folder: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct ProjectConfig {
+	#[serde(default)]
+	connections: HashMap<String, ConnectionDefinition>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConnectionDefinition {
+	host: Option<String>,
+	user: Option<String>,
+	#[serde(alias = "password")]
+	pass: Option<String>,
+	auth_level: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -83,10 +103,132 @@ fn resolve(
 	default.to_string()
 }
 
+fn read_project_config(toml_path: Option<&Path>) -> Result<ProjectConfig> {
+	let cfg_path = toml_path.unwrap_or_else(|| Path::new("surrealkit.toml"));
+	if !cfg_path.exists() {
+		return Ok(ProjectConfig::default());
+	}
+
+	let raw = std::fs::read_to_string(cfg_path)
+		.with_context(|| format!("reading {}", cfg_path.display()))?;
+	let cfg: ProjectConfig =
+		toml::from_str(&raw).with_context(|| format!("parsing {}", cfg_path.display()))?;
+	Ok(cfg)
+}
+
+fn normalized_connection_env_name(connection: &str) -> Result<String> {
+	let mut out = String::new();
+	let mut last_was_separator = false;
+
+	for ch in connection.chars() {
+		if ch.is_ascii_alphanumeric() {
+			out.push(ch.to_ascii_uppercase());
+			last_was_separator = false;
+		} else if !out.is_empty() && !last_was_separator {
+			out.push('_');
+			last_was_separator = true;
+		}
+	}
+
+	while out.ends_with('_') {
+		out.pop();
+	}
+
+	if out.is_empty() {
+		bail!(
+			"invalid connection {:?}: connection names must contain at least one ASCII letter or digit",
+			connection
+		);
+	}
+
+	Ok(out)
+}
+
+fn connection_env_key(connection_env_name: &str, field: &str) -> String {
+	format!("SURREALDB_CONNECTION_{connection_env_name}_{field}")
+}
+
+fn read_system_env(key: &str) -> Option<String> {
+	env::var(key).ok().filter(|v| !v.is_empty())
+}
+
+fn read_dotenv(dotenv: Option<&DotEnv>, key: &str) -> Option<String> {
+	dotenv.and_then(|dotenv| dotenv.get_var(key.to_string()).filter(|v| !v.is_empty()))
+}
+
+fn has_connection_env(connection_env_name: &str, dotenv: Option<&DotEnv>) -> bool {
+	["HOST", "USER", "PASSWORD", "AUTH_LEVEL"].iter().any(|field| {
+		let key = connection_env_key(connection_env_name, field);
+		read_system_env(&key).is_some() || read_dotenv(dotenv, &key).is_some()
+	})
+}
+
+fn resolve_connection_value(
+	cli: &Option<String>,
+	connection_env_name: Option<&str>,
+	connection_value: Option<&String>,
+	field: &str,
+	global_env_keys: &[&str],
+	dotenv: Option<&DotEnv>,
+	default: &str,
+) -> String {
+	if let Some(v) = cli {
+		return v.clone();
+	}
+
+	if let Some(connection_env_name) = connection_env_name {
+		let key = connection_env_key(connection_env_name, field);
+		if let Some(v) = read_system_env(&key) {
+			return v;
+		}
+		if let Some(v) = read_dotenv(dotenv, &key) {
+			return v;
+		}
+	}
+
+	if let Some(v) = connection_value {
+		return v.clone();
+	}
+
+	resolve(&None, global_env_keys, dotenv, default)
+}
+
 impl Cfg {
 	pub fn from_env(dotenv: Option<&DotEnv>, overrides: &ConfigOverrides) -> Result<Self> {
-		let host = resolve(
+		Self::from_env_with_project_config_path(dotenv, overrides, None)
+	}
+
+	fn from_env_with_project_config_path(
+		dotenv: Option<&DotEnv>,
+		overrides: &ConfigOverrides,
+		toml_path: Option<&Path>,
+	) -> Result<Self> {
+		let project_config = read_project_config(toml_path)?;
+		let connection_env_name =
+			overrides.connection.as_deref().map(normalized_connection_env_name).transpose()?;
+		let connection = if let Some(connection_name) = overrides.connection.as_deref() {
+			let connection = project_config.connections.get(connection_name);
+			if connection.is_none()
+				&& !connection_env_name
+					.as_deref()
+					.is_some_and(|env_name| has_connection_env(env_name, dotenv))
+			{
+				bail!(
+					"connection {:?} was not found in surrealkit.toml and no SURREALDB_CONNECTION_{}_* env vars were set",
+					connection_name,
+					connection_env_name.as_deref().unwrap_or("UNKNOWN")
+				);
+			}
+			connection
+		} else {
+			None
+		};
+
+		let host = resolve_connection_value(
 			&overrides.host,
+			connection_env_name.as_deref(),
+			connection.and_then(|connection| connection.host.as_ref()),
+			"HOST",
 			&["SURREALDB_HOST", "DATABASE_HOST"],
 			dotenv,
 			"http://localhost:8000",
@@ -94,11 +236,29 @@ impl Cfg {
 		let db = resolve(&overrides.db, &["SURREALDB_NAME", "DATABASE_NAME"], dotenv, "test");
 		let ns =
 			resolve(&overrides.ns, &["SURREALDB_NAMESPACE", "DATABASE_NAMESPACE"], dotenv, "db");
-		let user = resolve(&overrides.user, &["SURREALDB_USER", "DATABASE_USER"], dotenv, "root");
-		let pass =
-			resolve(&overrides.pass, &["SURREALDB_PASSWORD", "DATABASE_PASSWORD"], dotenv, "root");
-		let auth_level_str = resolve(
+		let user = resolve_connection_value(
+			&overrides.user,
+			connection_env_name.as_deref(),
+			connection.and_then(|connection| connection.user.as_ref()),
+			"USER",
+			&["SURREALDB_USER", "DATABASE_USER"],
+			dotenv,
+			"root",
+		);
+		let pass = resolve_connection_value(
+			&overrides.pass,
+			connection_env_name.as_deref(),
+			connection.and_then(|connection| connection.pass.as_ref()),
+			"PASSWORD",
+			&["SURREALDB_PASSWORD", "DATABASE_PASSWORD"],
+			dotenv,
+			"root",
+		);
+		let auth_level_str = resolve_connection_value(
 			&overrides.auth_level,
+			connection_env_name.as_deref(),
+			connection.and_then(|connection| connection.auth_level.as_ref()),
+			"AUTH_LEVEL",
 			&["SURREALDB_AUTH_LEVEL", "DATABASE_AUTH_LEVEL"],
 			dotenv,
 			"root",
@@ -183,7 +343,21 @@ mod tests {
 			unset_env("DATABASE_USER");
 			unset_env("DATABASE_PASSWORD");
 			unset_env("DATABASE_AUTH_LEVEL");
+			unset_env("SURREALDB_CONNECTION_LOCAL_HOST");
+			unset_env("SURREALDB_CONNECTION_LOCAL_USER");
+			unset_env("SURREALDB_CONNECTION_LOCAL_PASSWORD");
+			unset_env("SURREALDB_CONNECTION_LOCAL_AUTH_LEVEL");
+			unset_env("SURREALDB_CONNECTION_LOCAL_NAME");
+			unset_env("SURREALDB_CONNECTION_LOCAL_NAMESPACE");
+			unset_env("SURREALDB_CONNECTION_STAGING_US_HOST");
 		}
+	}
+
+	fn write_project_config(raw: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+		let tmp = tempfile::tempdir().unwrap();
+		let path = tmp.path().join("surrealkit.toml");
+		std::fs::write(&path, raw).unwrap();
+		(tmp, path)
 	}
 
 	// resolve() unit tests use unique key names, safe to run in parallel
@@ -262,6 +436,7 @@ mod tests {
 		let _guard = ENV_LOCK.lock().unwrap();
 		clear_db_env();
 		let overrides = ConfigOverrides {
+			connection: None,
 			host: Some("http://custom:9000".into()),
 			db: Some("mydb".into()),
 			ns: Some("myns".into()),
@@ -365,6 +540,250 @@ mod tests {
 		};
 		let cfg = Cfg::from_env(None, &overrides).unwrap();
 		assert_eq!(cfg.host(), "http://clihost:9000");
+		clear_db_env();
+	}
+
+	#[test]
+	fn from_env_reads_toml_connection_values() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		clear_db_env();
+		let (_tmp, cfg_path) = write_project_config(
+			r#"
+[connections.local]
+host = "http://tomlhost:8000"
+user = "tomluser"
+pass = "tomlpass"
+auth_level = "namespace"
+"#,
+		);
+		let overrides = ConfigOverrides {
+			connection: Some("local".into()),
+			..Default::default()
+		};
+
+		let cfg =
+			Cfg::from_env_with_project_config_path(None, &overrides, Some(&cfg_path)).unwrap();
+
+		assert_eq!(cfg.host(), "http://tomlhost:8000");
+		assert_eq!(cfg.user(), "tomluser");
+		assert_eq!(cfg.pass(), "tomlpass");
+		assert_eq!(cfg.auth_level(), &AuthLevel::Namespace);
+		assert_eq!(cfg.ns(), "db");
+		assert_eq!(cfg.db(), "test");
+	}
+
+	#[test]
+	fn from_env_accepts_password_alias_in_toml_connection() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		clear_db_env();
+		let (_tmp, cfg_path) = write_project_config(
+			r#"
+[connections.local]
+password = "tomlpass"
+"#,
+		);
+		let overrides = ConfigOverrides {
+			connection: Some("local".into()),
+			..Default::default()
+		};
+
+		let cfg =
+			Cfg::from_env_with_project_config_path(None, &overrides, Some(&cfg_path)).unwrap();
+
+		assert_eq!(cfg.pass(), "tomlpass");
+	}
+
+	#[test]
+	fn from_env_rejects_unknown_toml_connection_fields() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		clear_db_env();
+
+		for field in ["ns", "namespace", "db", "database"] {
+			let raw = format!(
+				r#"
+[connections.local]
+{field} = "not_allowed"
+"#
+			);
+			let (_tmp, cfg_path) = write_project_config(&raw);
+			let overrides = ConfigOverrides {
+				connection: Some("local".into()),
+				..Default::default()
+			};
+
+			let err = Cfg::from_env_with_project_config_path(None, &overrides, Some(&cfg_path))
+				.unwrap_err();
+			let err = format!("{err:#}");
+
+			assert!(err.contains("unknown field"), "got: {err}");
+			assert!(err.contains(field));
+		}
+	}
+
+	#[test]
+	fn connection_specific_env_overrides_toml_connection_values() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		clear_db_env();
+		let (_tmp, cfg_path) = write_project_config(
+			r#"
+[connections.local]
+host = "http://tomlhost:8000"
+"#,
+		);
+		unsafe { set_env("SURREALDB_CONNECTION_LOCAL_HOST", "http://connection-env:8000") };
+		let overrides = ConfigOverrides {
+			connection: Some("local".into()),
+			..Default::default()
+		};
+
+		let cfg =
+			Cfg::from_env_with_project_config_path(None, &overrides, Some(&cfg_path)).unwrap();
+
+		assert_eq!(cfg.host(), "http://connection-env:8000");
+		clear_db_env();
+	}
+
+	#[test]
+	fn connection_specific_dotenv_overrides_toml_connection_values() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		clear_db_env();
+		let (tmp, cfg_path) = write_project_config(
+			r#"
+[connections.local]
+user = "tomluser"
+"#,
+		);
+		std::fs::write(tmp.path().join(".env"), "SURREALDB_CONNECTION_LOCAL_USER=dotenvuser\n")
+			.unwrap();
+		let original_dir = env::current_dir().unwrap();
+		env::set_current_dir(tmp.path()).unwrap();
+		let dotenv = DotEnv::new("");
+		env::set_current_dir(original_dir).unwrap();
+		let overrides = ConfigOverrides {
+			connection: Some("local".into()),
+			..Default::default()
+		};
+
+		let cfg =
+			Cfg::from_env_with_project_config_path(Some(&dotenv), &overrides, Some(&cfg_path))
+				.unwrap();
+
+		assert_eq!(cfg.user(), "dotenvuser");
+	}
+
+	#[test]
+	fn cli_overrides_beat_connection_values() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		clear_db_env();
+		let (_tmp, cfg_path) = write_project_config(
+			r#"
+[connections.local]
+host = "http://tomlhost:8000"
+user = "tomluser"
+"#,
+		);
+		let overrides = ConfigOverrides {
+			connection: Some("local".into()),
+			host: Some("http://clihost:8000".into()),
+			user: Some("cliuser".into()),
+			..Default::default()
+		};
+
+		let cfg =
+			Cfg::from_env_with_project_config_path(None, &overrides, Some(&cfg_path)).unwrap();
+
+		assert_eq!(cfg.host(), "http://clihost:8000");
+		assert_eq!(cfg.user(), "cliuser");
+	}
+
+	#[test]
+	fn selected_connection_values_override_global_env_values() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		clear_db_env();
+		let (_tmp, cfg_path) = write_project_config(
+			r#"
+[connections.local]
+host = "http://tomlhost:8000"
+user = "tomluser"
+"#,
+		);
+		unsafe {
+			set_env("SURREALDB_HOST", "http://global-env:8000");
+			set_env("SURREALDB_USER", "globaluser");
+		}
+		let overrides = ConfigOverrides {
+			connection: Some("local".into()),
+			..Default::default()
+		};
+
+		let cfg =
+			Cfg::from_env_with_project_config_path(None, &overrides, Some(&cfg_path)).unwrap();
+
+		assert_eq!(cfg.host(), "http://tomlhost:8000");
+		assert_eq!(cfg.user(), "tomluser");
+		clear_db_env();
+	}
+
+	#[test]
+	fn selected_connection_does_not_affect_namespace_or_database() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		clear_db_env();
+		let (_tmp, cfg_path) = write_project_config(
+			r#"
+[connections.local]
+host = "http://tomlhost:8000"
+"#,
+		);
+		unsafe {
+			set_env("SURREALDB_NAMESPACE", "globalns");
+			set_env("SURREALDB_NAME", "globaldb");
+			set_env("SURREALDB_CONNECTION_LOCAL_NAMESPACE", "ignoredns");
+			set_env("SURREALDB_CONNECTION_LOCAL_NAME", "ignoreddb");
+		}
+		let overrides = ConfigOverrides {
+			connection: Some("local".into()),
+			..Default::default()
+		};
+
+		let cfg =
+			Cfg::from_env_with_project_config_path(None, &overrides, Some(&cfg_path)).unwrap();
+
+		assert_eq!(cfg.ns(), "globalns");
+		assert_eq!(cfg.db(), "globaldb");
+		clear_db_env();
+	}
+
+	#[test]
+	fn missing_selected_connection_returns_error() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		clear_db_env();
+		let (_tmp, cfg_path) = write_project_config("");
+		let overrides = ConfigOverrides {
+			connection: Some("missing".into()),
+			..Default::default()
+		};
+
+		let err =
+			Cfg::from_env_with_project_config_path(None, &overrides, Some(&cfg_path)).unwrap_err();
+
+		assert!(err.to_string().contains("connection \"missing\" was not found"));
+	}
+
+	#[test]
+	fn connection_names_normalize_for_env_keys() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		clear_db_env();
+		let (_tmp, cfg_path) = write_project_config("");
+		unsafe { set_env("SURREALDB_CONNECTION_STAGING_US_HOST", "http://staging-us:8000") };
+		let overrides = ConfigOverrides {
+			connection: Some("staging-us".into()),
+			..Default::default()
+		};
+
+		let cfg =
+			Cfg::from_env_with_project_config_path(None, &overrides, Some(&cfg_path)).unwrap();
+
+		assert_eq!(cfg.host(), "http://staging-us:8000");
 		clear_db_env();
 	}
 }

--- a/crates/surrealkit/src/main.rs
+++ b/crates/surrealkit/src/main.rs
@@ -18,6 +18,10 @@ pub struct Cli {
 	#[arg(short, long, global = true)]
 	verbose: bool,
 
+	/// Named connection from surrealkit.toml or SURREALDB_CONNECTION_<NAME>_* env vars
+	#[arg(long, visible_alias = "conn", global = true)]
+	connection: Option<String>,
+
 	/// Database host URL
 	#[arg(long, global = true)]
 	host: Option<String>,
@@ -159,6 +163,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let args = Cli::parse();
 	let env = load_env();
 	let overrides = ConfigOverrides {
+		connection: args.connection,
 		host: args.host,
 		ns: args.ns,
 		db: args.db,

--- a/crates/surrealkit/src/scaffold.rs
+++ b/crates/surrealkit/src/scaffold.rs
@@ -160,6 +160,16 @@ pub const DEFAULT_PROJECT_CONFIG: &str = r#"# Template variables for use in .sur
 # [variables]
 # schema_prefix = "myapp"
 # environment   = "development"
+#
+# Named connections for host/auth defaults.
+# Use with: surrealkit --connection local sync (or --conn local).
+# Connection-specific CLI flags such as --host, --user, and --pass override target-level values.
+#
+# [connections.local]
+# host       = "http://localhost:8000"
+# user       = "root"
+# pass       = "root"
+# auth_level = "root"
 "#;
 
 pub const DEFAULT_TEST_SUITE: &str = r#"name = "smoke"

--- a/crates/surrealkit/src/tester/mod.rs
+++ b/crates/surrealkit/src/tester/mod.rs
@@ -40,7 +40,7 @@ pub async fn run_test(
 		bail!("No suites matched the selected filters");
 	}
 
-	let base_url = resolve_base_url(&opts, &loaded.global);
+	let base_url = resolve_base_url(&opts, &loaded.global, cfg.host());
 	let timeout_ms = resolve_timeout_ms(&opts, &loaded.global);
 	let ctx =
 		runner::RunnerContext::new(cfg, opts.clone(), loaded.global, base_url, timeout_ms, vars);
@@ -56,13 +56,16 @@ pub async fn run_test(
 	Ok(())
 }
 
-fn resolve_base_url(opts: &TestOpts, global: &types::GlobalTestConfig) -> Option<String> {
+fn resolve_base_url(
+	opts: &TestOpts,
+	global: &types::GlobalTestConfig,
+	resolved_host: &str,
+) -> Option<String> {
 	opts.base_url
 		.clone()
 		.or_else(|| global.defaults.base_url.clone())
 		.or_else(|| env::var("SURREALKIT_TEST_BASE_URL").ok())
-		.or_else(|| env::var("SURREALDB_HOST").ok())
-		.or_else(|| env::var("DATABASE_HOST").ok())
+		.or_else(|| Some(resolved_host.to_string()))
 		.map(normalize_base_url)
 }
 
@@ -83,4 +86,59 @@ fn normalize_base_url(raw: String) -> String {
 		return format!("https://{rest}");
 	}
 	raw
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::Mutex;
+
+	use super::*;
+
+	static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+	fn opts(base_url: Option<&str>) -> TestOpts {
+		TestOpts {
+			suite: None,
+			case: None,
+			tags: Vec::new(),
+			fail_fast: false,
+			parallel: 1,
+			json_out: None,
+			no_setup: false,
+			no_sync: false,
+			no_seed: false,
+			base_url: base_url.map(str::to_string),
+			timeout_ms: None,
+			keep_db: false,
+		}
+	}
+
+	#[test]
+	fn base_url_falls_back_to_resolved_host() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		unsafe { env::remove_var("SURREALKIT_TEST_BASE_URL") };
+
+		let base_url = resolve_base_url(
+			&opts(None),
+			&types::GlobalTestConfig::default(),
+			"ws://target-host:8000",
+		);
+
+		assert_eq!(base_url.as_deref(), Some("http://target-host:8000"));
+	}
+
+	#[test]
+	fn test_specific_base_url_beats_resolved_host() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		unsafe { env::set_var("SURREALKIT_TEST_BASE_URL", "http://env-host:8000") };
+
+		let base_url = resolve_base_url(
+			&opts(Some("http://cli-host:8000")),
+			&types::GlobalTestConfig::default(),
+			"http://target-host:8000",
+		);
+
+		assert_eq!(base_url.as_deref(), Some("http://cli-host:8000"));
+		unsafe { env::remove_var("SURREALKIT_TEST_BASE_URL") };
+	}
 }

--- a/crates/surrealkit/tests/auth_levels.rs
+++ b/crates/surrealkit/tests/auth_levels.rs
@@ -50,6 +50,7 @@ fn make_cfg(url: &str, auth_level: AuthLevel, user: &str, pass: &str) -> Cfg {
 	Cfg::from_env(
 		None,
 		&ConfigOverrides {
+			connection: None,
 			host: Some(url.into()),
 			ns: Some(NS.into()),
 			db: Some(DB.into()),

--- a/example.env
+++ b/example.env
@@ -5,6 +5,14 @@ SURREALDB_USER=
 SURREALDB_PASSWORD=
 SURREALDB_FOLDER=
 
+# Named connections.
+# Use with: surrealkit --connection local sync (or --conn local).
+# Namespace/database remain global via SURREALDB_NAMESPACE/SURREALDB_NAME.
+# SURREALDB_CONNECTION_LOCAL_HOST=http://localhost:8000
+# SURREALDB_CONNECTION_LOCAL_USER=root
+# SURREALDB_CONNECTION_LOCAL_PASSWORD=root
+# SURREALDB_CONNECTION_LOCAL_AUTH_LEVEL=root
+
 # Legacy env vars (still supported as fallback)
 # DATABASE_HOST=
 # DATABASE_NAME=


### PR DESCRIPTION
Adds named connections for SurrealDB host/auth defaults, so you can point SurrealKit at different servers without repeating --host, --user, and --pass or modifying a .env config every time.

- New global `--connection` flag (alias: `--conn`)
- New `surrealkit.toml` section: `[connections.<name>]`
- New env vars: `SURREALDB_CONNECTION_<NAME>_HOST`, `_USER`, `_PASSWORD`, `_AUTH_LEVEL`
- When a connection is selected, host/auth resolve as: `CLI > connection env > .env > TOML > global env > defaults`

### Example:
```toml
# surrealkit.toml

[connections.local]
host = "http://localhost:8000"
user = "root"
pass = "root"
auth_level = "root"
```
or
```env
# .env

SURREALDB_CONNECTION_LOCAL_HOST=http://localhost:8000
SURREALDB_CONNECTION_LOCAL_USER=root
SURREALDB_CONNECTION_LOCAL_PASSWORD=root
SURREALDB_CONNECTION_LOCAL_AUTH_LEVEL=root
```
```
surrealkit --connection local --ns my_ns --db my_db sync
surrealkit --conn prod rollout start 20260522__my_rollout
```