### PR TITLE
Update README example for template vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SurrealKit
 
 [![Crates.io](https://img.shields.io/crates/v/surrealkit.svg)](https://crates.io/crates/surrealkit) [![Documentation](https://docs.rs/surrealkit/badge.svg)](https://docs.rs/surrealkit)
-[![License](https://img.shields.io/badge/license-Unlicense-blue.svg)](https://unlicense.org/)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 SurrealKit is a schema management and migration tool for SurrealDB. It lets you define your schema as `.surql` files and keeps your database in sync with them.
 

--- a/README.md
+++ b/README.md
@@ -236,12 +236,12 @@ surrealkit seed
 Use `${VAR_NAME}` tokens in any `.surql` file (schema, seed, or rollout SQL) and bind values to them at runtime. Useful for credentials, table prefixes, or environment names that differ between dev, staging, and prod.
 
 ```sql
--- database/schema/roles.surql
-DROP ROLE IF EXISTS ${talent_username};
-DEFINE ROLE ${talent_username} PERMISSIONS FULL;
+-- database/schema/access.surql
+REMOVE USER IF EXISTS ${talent_username} ON DATABASE;
+DEFINE USER ${talent_username} ON DATABASE PASSWORD "${talent_password}" ROLES EDITOR;
 
 -- database/schema/tables.surql
-DEFINE TABLE ${schema_prefix}_users SCHEMAFULL;
+DEFINE TABLE IF NOT EXISTS ${schema_prefix}_users SCHEMAFULL;
 ```
 
 ### Resolution Priority
@@ -264,6 +264,7 @@ Place a `surrealkit.toml` at the project root (created by `surrealkit init`):
 [variables]
 schema_prefix = "myapp"
 talent_username = "talent_rw"
+talent_password = "change_me_in_prod"
 environment = "development"
 ```
 

--- a/crates/surrealkit-macros/Cargo.toml
+++ b/crates/surrealkit-macros/Cargo.toml
@@ -4,7 +4,7 @@ version = '0.6.3'
 edition = '2024'
 authors = ['Chiru Boggavarapu <chiru@foretag.co>', 'Tobie Morgan Hitchcock <tobie@surrealdb.com>']
 repository = 'https://github.com/surrealdb/surrealkit'
-license-file = 'LICENSE'
+license = 'Apache-2.0'
 description = 'Proc-macros for SurrealKit - embed schema files at compile time'
 
 [lib]

--- a/crates/surrealkit/Cargo.toml
+++ b/crates/surrealkit/Cargo.toml
@@ -5,7 +5,7 @@ version = '0.6.3'
 edition = '2024'
 authors = ['Chiru Boggavarapu <chiru@foretag.co>', 'Tobie Morgan Hitchcock <tobie@surrealdb.com>']
 repository = 'https://github.com/surrealdb/surrealkit'
-license-file = 'LICENSE'
+license = 'Apache-2.0'
 keywords = ['surrealdb', 'migrations', 'seed', 'testing', 'manage']
 
 [dependencies]


### PR DESCRIPTION
The current example on template vars is invalid SurrealQL, this PR updates that with valid SurrealQL for SurrealDB v3.

Also updates the LICENSE badge as well as the crate's `Cargo.toml` to Apache-2.0