### PR TITLE
Add Templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
@@ -789,6 +795,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +998,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "earcutr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,7 +1179,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "rustc_version",
  "serde",
 ]
@@ -1304,6 +1341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1963,6 +2009,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.9.4",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,6 +2312,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
@@ -2293,6 +2368,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "nibble_vec"
@@ -2408,7 +2492,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -3063,7 +3147,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -3469,7 +3553,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3636,7 +3720,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3770,6 +3854,27 @@ name = "sif-itree"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142099cd6db3c4fab61e5133c62ff80b26674391e195860791fda0b1be3e5080"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4133,6 +4238,7 @@ dependencies = [
  "anyhow",
  "clap",
  "hex",
+ "inquire",
  "regex",
  "reqwest 0.12.28",
  "rust_dotenv",
@@ -4415,7 +4521,7 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.0.4",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4633,7 +4739,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "bytes",
  "futures-util",
  "http",
@@ -4753,6 +4859,18 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"
@@ -5197,6 +5315,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5244,6 +5371,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5296,6 +5438,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5314,6 +5462,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5329,6 +5483,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5362,6 +5522,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5377,6 +5543,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5398,6 +5570,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5413,6 +5591,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Initialise a new project:
 surrealkit init
 ```
 
-This creates a directory `/database` with the necessary scaffolding
+This creates a `database/` directory with the project scaffolding and lets you pick optional features to include. See [Templates](#templates) for details.
 
 Connection details can be provided via CLI arguments, environment variables, or a `.env` file. The resolution order is: CLI args > system env vars > `.env` file > defaults.
 
@@ -114,6 +114,95 @@ surrealkit --host http://localhost:8000 --ns my_ns --db my_db --user root --pass
 These can be set as system environment variables or in a `.env` file.
 
 SurrealKit creates and manages its internal sync and rollout metadata tables on your configured database.
+
+## Templates
+
+`surrealkit init` scaffolds a project from a template and lets you choose which optional features to include:
+
+```sh
+surrealkit init
+```
+
+In a terminal this shows a checklist of the template's features. Pick the ones you want and SurrealKit writes their schema, seed, and test files into `database/`. It always creates the base layout first: `schema/`, `rollouts/`, `snapshots/`, `seed/`, `tests/`, `setup.surql`, and `surrealkit.toml`.
+
+### Choosing features without a prompt
+
+When there is no terminal (such as CI) or you pass any of these flags, init runs without prompting:
+
+| Flag             | Behaviour                                                            |
+| ---------------- | ------------------------------------------------------------------- |
+| `--feature <id>` | Enable a feature by id. Repeatable, and pulls in what it requires.  |
+| `-y`, `--yes`    | Take the template's default features.                               |
+| `--minimal`      | Scaffold the base project only, with no features.                   |
+| `--force`        | Overwrite files that already exist. The default is to skip them.    |
+
+```sh
+surrealkit init --feature organizations --feature teams
+surrealkit init -y
+surrealkit init --minimal
+```
+
+A feature can depend on other features. Selecting one adds what it requires, and init prints what it added.
+
+### Using your own template
+
+Point `--from` at a local path or a git repository instead of the bundled template, or pick a bundled template by name with `--template`:
+
+```sh
+surrealkit init --from ./path/to/template
+surrealkit init --from https://github.com/your-org/your-template.git
+surrealkit init --from https://github.com/your-org/your-template.git#v1.0.0
+surrealkit init --template default
+```
+
+Git sources are cloned with `git clone --depth 1`, so `git` must be on your PATH. Pin a branch, tag, or commit with `#rev`, and target a subdirectory with `#rev:subdir`.
+
+### Template layout
+
+A template is a directory with a `template.toml` manifest plus the files each feature contributes:
+
+```toml
+schema_version = 1
+name = "default"
+display_name = "My starter"
+description = "Shown above the feature checklist"
+
+[[features]]
+id = "organizations"
+name = "Organizations"
+description = "Shown next to the feature in the checklist"
+default = false
+schema   = ["schema/organization/organization.surql"]
+seed     = ["seed/organization_permissions.surql"]
+suites   = ["tests/suites/organization.toml"]
+fixtures = ["tests/fixtures/organization_seed.surql"]
+
+[[features]]
+id = "teams"
+name = "Teams"
+requires = ["organizations"]
+schema = ["schema/team/team.surql"]
+```
+
+Each feature lists the files it adds, grouped by where they land:
+
+- `schema` files are copied into `database/schema/`
+- `seed` files into `database/seed/`
+- `suites` files into `database/tests/suites/`
+- `fixtures` files into `database/tests/fixtures/`
+
+Set `default = true` to pre-check a feature in the prompt and include it with `-y`. Use `requires` to declare dependencies on other features.
+
+### Bundled template
+
+The bundled template provides an organization and access-control model with four opt-in features:
+
+- **Organizations**: organizations, roles that bundle permissions, a per-app permission catalog, employees, and invitations.
+- **Teams**: teams within an organization, with per-member roles.
+- **Organization units**: a department and region hierarchy with unit-scoped permissions.
+- **Subsidiaries and delegation**: parent and child organizations with cross-org delegated permissions.
+
+Teams, units, and subsidiaries each require the organizations feature.
 
 ## Team Workflow
 

--- a/crates/surrealkit/Cargo.toml
+++ b/crates/surrealkit/Cargo.toml
@@ -26,10 +26,11 @@ walkdir = '2.5'
 reqwest = { version = '0.12', default-features = false, features = ['json', 'rustls-tls'] }
 regex = '1'
 rustls = { version = '0.23', default-features = false, features = ['aws-lc-rs'] }
+inquire = '0.7'
+tempfile = '3'
 
 [dev-dependencies]
 surrealdb = { version = '3.0.5', features = ['kv-mem'] }
-tempfile = '3'
 test-case = "3"
 
 [lints]

--- a/crates/surrealkit/build.rs
+++ b/crates/surrealkit/build.rs
@@ -1,0 +1,61 @@
+//! Embeds the repo's `/templates` tree into the binary at compile time.
+//!
+//! Generates `$OUT_DIR/embedded_templates.rs` defining a `TEMPLATES` static of
+//! `EmbeddedTemplateFile` entries (one per file), which `templates::source`
+//! `include!`s. Kept as a build script (rather than a proc-macro) so the
+//! init-only template machinery stays out of the public `surrealkit-macros` and
+//! `surrealkit` library surfaces.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+fn main() {
+	let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+	let templates_dir = PathBuf::from(&manifest_dir)
+		.join("../../templates")
+		.canonicalize()
+		.expect("templates directory not found");
+
+	println!("cargo:rerun-if-changed={}", templates_dir.display());
+
+	let mut files = Vec::new();
+	collect_files(&templates_dir, &mut files);
+	files.sort();
+
+	let mut out = String::from("pub static TEMPLATES: &[EmbeddedTemplateFile] = &[\n");
+	for file in &files {
+		println!("cargo:rerun-if-changed={}", file.display());
+		let rel = file
+			.strip_prefix(&templates_dir)
+			.expect("path under templates dir")
+			.to_string_lossy()
+			.replace('\\', "/");
+		let abs = file.to_string_lossy();
+		writeln!(
+			out,
+			"    EmbeddedTemplateFile {{ path: {rel:?}, contents: include_str!({abs:?}) }},"
+		)
+		.expect("write generated entry");
+	}
+	out.push_str("];\n");
+
+	let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR");
+	std::fs::write(Path::new(&out_dir).join("embedded_templates.rs"), out)
+		.expect("writing embedded_templates.rs");
+}
+
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) {
+	let entries = match std::fs::read_dir(dir) {
+		Ok(e) => e,
+		Err(_) => return,
+	};
+	for entry in entries.flatten() {
+		let path = entry.path();
+		if path.is_dir() {
+			println!("cargo:rerun-if-changed={}", path.display());
+			collect_files(&path, out);
+		} else if path.is_file() {
+			out.push(path);
+		}
+	}
+}

--- a/crates/surrealkit/src/main.rs
+++ b/crates/surrealkit/src/main.rs
@@ -5,12 +5,18 @@ use rust_dotenv::dotenv::DotEnv;
 use surrealkit::config::{Cfg, ConfigOverrides, connect};
 use surrealkit::core::exec_surql;
 use surrealkit::rollout::{self, RolloutExecutionOpts, RolloutPlanOpts};
+use surrealkit::seed;
 use surrealkit::setup::run_setup;
 use surrealkit::sync::{self, SyncOpts};
 use surrealkit::tester::{TestOpts, run_test};
 use surrealkit::typegen::{TypegenOpts, run_typegen};
 use surrealkit::variables::{TemplateVars, build_vars, parse_var_flag};
-use surrealkit::{scaffold, seed};
+
+use crate::templates::InitOpts;
+
+// `init` templates are a CLI-only concern, so the module lives in the binary
+// rather than the public library surface.
+mod templates;
 
 #[derive(Parser, Debug)]
 #[command(version, about = "SurrealKit CLI")]
@@ -57,7 +63,28 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-	Init,
+	/// Scaffold a new project from a template, selecting optional features.
+	Init {
+		/// Bundled template name (default: `default`). Ignored when --from is set.
+		#[arg(long)]
+		template: Option<String>,
+		/// Use an external template: a git URL (optionally `url#rev` / `url#rev:subdir`)
+		/// or a local path. Overrides --template.
+		#[arg(long)]
+		from: Option<String>,
+		/// Enable a feature by id (repeatable). Implies non-interactive selection.
+		#[arg(long = "feature", value_name = "ID")]
+		feature: Vec<String>,
+		/// Only scaffold the bare project; add no template features.
+		#[arg(long)]
+		minimal: bool,
+		/// Don't prompt; accept the default features (non-interactive).
+		#[arg(short = 'y', long)]
+		yes: bool,
+		/// Overwrite files that already exist.
+		#[arg(long)]
+		force: bool,
+	},
 	Setup,
 	Sync {
 		#[arg(long)]
@@ -195,7 +222,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let folder = cfg.folder().to_owned();
 
 	match args.command {
-		Commands::Init => scaffold::scaffold(&folder)?,
+		Commands::Init {
+			template,
+			from,
+			feature,
+			minimal,
+			yes,
+			force,
+		} => templates::run_init(
+			&folder,
+			InitOpts {
+				template,
+				from,
+				feature,
+				minimal,
+				yes,
+				force,
+			},
+		)?,
 		Commands::Setup => {
 			let db = connect(&cfg).await?;
 			run_setup(&db, &folder).await?;

--- a/crates/surrealkit/src/templates/emit.rs
+++ b/crates/surrealkit/src/templates/emit.rs
@@ -1,0 +1,237 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+
+use super::manifest::{Feature, TemplateManifest};
+use super::source::TemplateFiles;
+use surrealkit::constants::{fixtures_dir, schema_dir, seed_dir, suites_dir};
+
+/// One file to write, with its resolved content already loaded from the source.
+#[derive(Debug, Clone)]
+pub struct EmitFile {
+	pub dest: PathBuf,
+	pub contents: String,
+	pub feature_id: String,
+}
+
+/// The full set of files to write for a selection of features.
+#[derive(Debug, Default)]
+pub struct EmitPlan {
+	pub files: Vec<EmitFile>,
+}
+
+/// Where each kind of file lands, preserving the relative subpath.
+enum Dest {
+	Schema,
+	Seed,
+	Suite,
+	Fixture,
+}
+
+impl EmitPlan {
+	/// Build a plan for `feature_ids` (already dependency-closed) by reading
+	/// every contributed file from `source`. Detects cross-feature conflicts:
+	/// two features targeting the same destination with differing content.
+	pub fn build(
+		folder: &str,
+		manifest: &TemplateManifest,
+		feature_ids: &[String],
+		source: &dyn TemplateFiles,
+	) -> Result<Self> {
+		let mut files = Vec::new();
+		for id in feature_ids {
+			let feature = manifest
+				.feature(id)
+				.with_context(|| format!("feature '{id}' missing from manifest"))?;
+			collect(folder, feature, Dest::Schema, &feature.schema, source, &mut files)?;
+			collect(folder, feature, Dest::Seed, &feature.seed, source, &mut files)?;
+			collect(folder, feature, Dest::Suite, &feature.suites, source, &mut files)?;
+			collect(folder, feature, Dest::Fixture, &feature.fixtures, source, &mut files)?;
+		}
+
+		// Conflict detection: same dest, different content -> hard error before
+		// any write, so emission stays all-or-nothing.
+		let mut by_dest: HashMap<PathBuf, &EmitFile> = HashMap::new();
+		for file in &files {
+			if let Some(prev) = by_dest.get(&file.dest) {
+				if prev.contents != file.contents {
+					bail!(
+						"templates conflict: features '{}' and '{}' both write {} with different content",
+						prev.feature_id,
+						file.feature_id,
+						file.dest.display()
+					);
+				}
+			} else {
+				by_dest.insert(file.dest.clone(), file);
+			}
+		}
+
+		Ok(EmitPlan {
+			files,
+		})
+	}
+
+	/// Write the plan. Skips files that already exist unless `force`. De-dupes
+	/// identical (dest, content) pairs that two features legitimately share.
+	pub fn write(&self, force: bool) -> Result<()> {
+		let mut written: HashMap<&PathBuf, &str> = HashMap::new();
+		for file in &self.files {
+			// A duplicate already emitted this run with identical content: skip silently.
+			if written.get(&file.dest).is_some_and(|c| *c == file.contents) {
+				continue;
+			}
+
+			if file.dest.exists() && !force {
+				println!("  skipped (exists): {}", display_rel(&file.dest));
+				continue;
+			}
+
+			if let Some(parent) = file.dest.parent() {
+				std::fs::create_dir_all(parent)
+					.with_context(|| format!("creating {}", parent.display()))?;
+			}
+			std::fs::write(&file.dest, &file.contents)
+				.with_context(|| format!("writing {}", file.dest.display()))?;
+			println!("  + {}", display_rel(&file.dest));
+			written.insert(&file.dest, &file.contents);
+		}
+		Ok(())
+	}
+}
+
+fn collect(
+	folder: &str,
+	feature: &Feature,
+	dest: Dest,
+	rels: &[String],
+	source: &dyn TemplateFiles,
+	out: &mut Vec<EmitFile>,
+) -> Result<()> {
+	let base = match dest {
+		Dest::Schema => schema_dir(folder),
+		Dest::Seed => seed_dir(folder),
+		Dest::Suite => suites_dir(folder),
+		Dest::Fixture => fixtures_dir(folder),
+	};
+	let strip = match dest {
+		Dest::Schema => "schema/",
+		Dest::Seed => "seed/",
+		Dest::Suite => "tests/suites/",
+		Dest::Fixture => "tests/fixtures/",
+	};
+	for rel in rels {
+		let contents = source.read_file(rel)?;
+		// Preserve subpaths but drop the leading `schema/` / `tests/...` segment
+		// so files land directly under the target dir.
+		let leaf = rel.strip_prefix(strip).unwrap_or(rel);
+		out.push(EmitFile {
+			dest: base.join(leaf),
+			contents,
+			feature_id: feature.id.clone(),
+		});
+	}
+	Ok(())
+}
+
+/// Render a path relative to the current dir when possible, for tidy output.
+fn display_rel(path: &std::path::Path) -> String {
+	std::env::current_dir()
+		.ok()
+		.and_then(|cwd| path.strip_prefix(&cwd).ok().map(|p| p.to_path_buf()))
+		.unwrap_or_else(|| path.to_path_buf())
+		.display()
+		.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+	use std::collections::HashMap;
+
+	use super::*;
+
+	struct MapSource(HashMap<String, String>);
+	impl TemplateFiles for MapSource {
+		fn read_manifest(&self) -> Result<String> {
+			Ok(self.0.get("template.toml").cloned().unwrap_or_default())
+		}
+		fn read_file(&self, rel: &str) -> Result<String> {
+			self.0.get(rel).cloned().ok_or_else(|| anyhow::anyhow!("missing {rel}"))
+		}
+	}
+
+	fn manifest() -> TemplateManifest {
+		TemplateManifest::parse(
+			r#"
+schema_version = 1
+name = "t"
+[[features]]
+id = "a"
+name = "A"
+schema = ["schema/org.surql"]
+seed = ["seed/perms.surql"]
+suites = ["tests/suites/a.toml"]
+[[features]]
+id = "b"
+name = "B"
+schema = ["schema/org.surql"]
+"#,
+		)
+		.unwrap()
+	}
+
+	#[test]
+	fn maps_files_to_destinations() {
+		let mut files = HashMap::new();
+		files.insert("schema/org.surql".to_string(), "DEFINE TABLE org;".to_string());
+		files.insert("seed/perms.surql".to_string(), "UPSERT perm;".to_string());
+		files.insert("tests/suites/a.toml".to_string(), "name='a'".to_string());
+		let src = MapSource(files);
+		let plan = EmitPlan::build("./database", &manifest(), &["a".to_string()], &src).unwrap();
+		let dests: Vec<String> = plan.files.iter().map(|f| f.dest.display().to_string()).collect();
+		assert!(dests.iter().any(|d| d.ends_with("database/schema/org.surql")));
+		assert!(dests.iter().any(|d| d.ends_with("database/seed/perms.surql")));
+		assert!(dests.iter().any(|d| d.ends_with("database/tests/suites/a.toml")));
+	}
+
+	#[test]
+	fn identical_shared_file_is_not_a_conflict() {
+		let mut files = HashMap::new();
+		files.insert("schema/org.surql".to_string(), "same".to_string());
+		files.insert("seed/perms.surql".to_string(), "UPSERT perm;".to_string());
+		files.insert("tests/suites/a.toml".to_string(), "x".to_string());
+		let src = MapSource(files);
+		// a and b both contribute schema/org.surql with identical content.
+		let plan = EmitPlan::build("./db", &manifest(), &["a".to_string(), "b".to_string()], &src)
+			.unwrap();
+		assert!(!plan.files.is_empty());
+	}
+
+	#[test]
+	fn conflicting_shared_file_errors() {
+		// Both features write schema/org.surql but with different content -> conflict.
+		let mut files = HashMap::new();
+		files.insert("schema/org.surql".to_string(), "one".to_string());
+		files.insert("seed/perms.surql".to_string(), "UPSERT perm;".to_string());
+		files.insert("tests/suites/a.toml".to_string(), "x".to_string());
+		let src = MapSourceVarying(files);
+		let err = EmitPlan::build("./db", &manifest(), &["a".to_string(), "b".to_string()], &src)
+			.unwrap_err();
+		assert!(err.to_string().contains("conflict"), "{err}");
+	}
+
+	// Returns a different body each read of the same key, to force a content mismatch.
+	struct MapSourceVarying(HashMap<String, String>);
+	impl TemplateFiles for MapSourceVarying {
+		fn read_manifest(&self) -> Result<String> {
+			Ok(String::new())
+		}
+		fn read_file(&self, rel: &str) -> Result<String> {
+			use std::sync::atomic::{AtomicUsize, Ordering};
+			static N: AtomicUsize = AtomicUsize::new(0);
+			let base = self.0.get(rel).cloned().ok_or_else(|| anyhow::anyhow!("missing {rel}"))?;
+			Ok(format!("{base}-{}", N.fetch_add(1, Ordering::SeqCst)))
+		}
+	}
+}

--- a/crates/surrealkit/src/templates/manifest.rs
+++ b/crates/surrealkit/src/templates/manifest.rs
@@ -1,0 +1,276 @@
+use std::collections::{BTreeSet, HashMap};
+
+use anyhow::{Result, bail};
+use serde::Deserialize;
+
+/// The manifest schema versions this build understands. Bump when the format
+/// changes in a backward-incompatible way.
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 1;
+
+/// A parsed `template.toml`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TemplateManifest {
+	pub schema_version: u32,
+	pub name: String,
+	#[serde(default)]
+	pub display_name: Option<String>,
+	#[serde(default)]
+	pub description: Option<String>,
+	#[serde(default)]
+	pub features: Vec<Feature>,
+}
+
+/// One optionally-selectable feature within a template.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Feature {
+	/// Stable machine id, used by `--feature` and for dependency edges.
+	pub id: String,
+	/// Human label shown in the multi-select prompt.
+	pub name: String,
+	#[serde(default)]
+	pub description: Option<String>,
+	/// Whether the feature is pre-checked / included by `--yes`.
+	#[serde(default)]
+	pub default: bool,
+	/// Other feature ids this feature depends on (closed transitively).
+	#[serde(default)]
+	pub requires: Vec<String>,
+	/// Files copied into `<folder>/schema/`, preserving their relative subpath.
+	#[serde(default)]
+	pub schema: Vec<String>,
+	/// Files copied into `<folder>/seed/` (reference data, run by `surrealkit seed`).
+	#[serde(default)]
+	pub seed: Vec<String>,
+	/// Files copied into `<folder>/tests/suites/`.
+	#[serde(default)]
+	pub suites: Vec<String>,
+	/// Files copied into `<folder>/tests/fixtures/`.
+	#[serde(default)]
+	pub fixtures: Vec<String>,
+}
+
+impl Feature {
+	/// All source paths this feature contributes, across destinations.
+	pub fn all_paths(&self) -> impl Iterator<Item = &str> {
+		self.schema
+			.iter()
+			.chain(self.seed.iter())
+			.chain(self.suites.iter())
+			.chain(self.fixtures.iter())
+			.map(String::as_str)
+	}
+}
+
+impl TemplateManifest {
+	/// Parse and validate a manifest from raw TOML.
+	pub fn parse(raw: &str) -> Result<Self> {
+		let manifest: TemplateManifest =
+			toml::from_str(raw).map_err(|e| anyhow::anyhow!("invalid template.toml: {e}"))?;
+		manifest.validate()?;
+		Ok(manifest)
+	}
+
+	pub fn feature(&self, id: &str) -> Option<&Feature> {
+		self.features.iter().find(|f| f.id == id)
+	}
+
+	/// Validate schema version, unique ids, resolvable `requires`, no cycles,
+	/// and safe (relative, no `..`) file paths.
+	fn validate(&self) -> Result<()> {
+		if self.schema_version > SUPPORTED_SCHEMA_VERSION {
+			bail!(
+				"template '{}' requires schema_version {} but this surrealkit understands up to {}; \
+                 upgrade surrealkit",
+				self.name,
+				self.schema_version,
+				SUPPORTED_SCHEMA_VERSION
+			);
+		}
+
+		let mut seen = BTreeSet::new();
+		for f in &self.features {
+			if !seen.insert(f.id.as_str()) {
+				bail!("duplicate feature id '{}' in template '{}'", f.id, self.name);
+			}
+		}
+
+		for f in &self.features {
+			for dep in &f.requires {
+				if self.feature(dep).is_none() {
+					bail!("feature '{}' requires unknown feature '{}'", f.id, dep);
+				}
+			}
+			for path in f.all_paths() {
+				if path.is_empty() {
+					bail!("feature '{}' has an empty file path", f.id);
+				}
+				let p = std::path::Path::new(path);
+				if p.is_absolute() || path.split(['/', '\\']).any(|c| c == "..") {
+					bail!(
+						"feature '{}' has an unsafe file path '{}' (must be relative, no '..')",
+						f.id,
+						path
+					);
+				}
+			}
+		}
+
+		self.detect_cycles()?;
+		Ok(())
+	}
+
+	fn detect_cycles(&self) -> Result<()> {
+		// 0 = unvisited, 1 = on stack, 2 = done
+		let mut state: HashMap<&str, u8> = HashMap::new();
+		for f in &self.features {
+			self.visit(&f.id, &mut state)?;
+		}
+		Ok(())
+	}
+
+	fn visit<'a>(&'a self, id: &'a str, state: &mut HashMap<&'a str, u8>) -> Result<()> {
+		match state.get(id) {
+			Some(2) => return Ok(()),
+			Some(1) => bail!("dependency cycle detected involving feature '{}'", id),
+			_ => {}
+		}
+		state.insert(id, 1);
+		if let Some(f) = self.feature(id) {
+			for dep in &f.requires {
+				self.visit(dep, state)?;
+			}
+		}
+		state.insert(id, 2);
+		Ok(())
+	}
+
+	/// Expand a selection of feature ids to include all transitive `requires`.
+	/// Returns the closed set in manifest order. Errors on unknown ids.
+	pub fn resolve_closure(&self, selected: &[String]) -> Result<Vec<String>> {
+		let mut included: BTreeSet<String> = BTreeSet::new();
+		for id in selected {
+			if self.feature(id).is_none() {
+				let known: Vec<&str> = self.features.iter().map(|f| f.id.as_str()).collect();
+				bail!("unknown feature '{}' (available: {})", id, known.join(", "));
+			}
+			self.collect_requires(id, &mut included);
+		}
+		// Preserve manifest declaration order for stable output.
+		Ok(self.features.iter().map(|f| f.id.clone()).filter(|id| included.contains(id)).collect())
+	}
+
+	fn collect_requires(&self, id: &str, acc: &mut BTreeSet<String>) {
+		if !acc.insert(id.to_string()) {
+			return;
+		}
+		if let Some(f) = self.feature(id) {
+			for dep in &f.requires {
+				self.collect_requires(dep, acc);
+			}
+		}
+	}
+
+	/// Ids of features marked `default = true`.
+	pub fn default_feature_ids(&self) -> Vec<String> {
+		self.features.iter().filter(|f| f.default).map(|f| f.id.clone()).collect()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const SAMPLE: &str = r#"
+schema_version = 1
+name = "default"
+
+[[features]]
+id = "organizations"
+name = "Organizations"
+default = true
+schema = ["schema/org.surql"]
+
+[[features]]
+id = "teams"
+name = "Teams"
+requires = ["organizations"]
+schema = ["schema/team.surql"]
+"#;
+
+	#[test]
+	fn parses_and_validates_sample() {
+		let m = TemplateManifest::parse(SAMPLE).unwrap();
+		assert_eq!(m.features.len(), 2);
+		assert_eq!(m.default_feature_ids(), vec!["organizations"]);
+	}
+
+	#[test]
+	fn closure_pulls_in_requires() {
+		let m = TemplateManifest::parse(SAMPLE).unwrap();
+		let closed = m.resolve_closure(&["teams".to_string()]).unwrap();
+		assert_eq!(closed, vec!["organizations", "teams"]);
+	}
+
+	#[test]
+	fn unknown_feature_errors() {
+		let m = TemplateManifest::parse(SAMPLE).unwrap();
+		let err = m.resolve_closure(&["nope".to_string()]).unwrap_err();
+		assert!(err.to_string().contains("unknown feature 'nope'"));
+		assert!(err.to_string().contains("organizations"));
+	}
+
+	#[test]
+	fn rejects_future_schema_version() {
+		let raw = "schema_version = 99\nname = \"x\"\n";
+		let err = TemplateManifest::parse(raw).unwrap_err();
+		assert!(err.to_string().contains("schema_version"));
+	}
+
+	#[test]
+	fn rejects_unknown_requires() {
+		let raw = r#"
+schema_version = 1
+name = "x"
+[[features]]
+id = "a"
+name = "A"
+requires = ["ghost"]
+"#;
+		let err = TemplateManifest::parse(raw).unwrap_err();
+		assert!(err.to_string().contains("unknown feature 'ghost'"));
+	}
+
+	#[test]
+	fn rejects_dependency_cycle() {
+		let raw = r#"
+schema_version = 1
+name = "x"
+[[features]]
+id = "a"
+name = "A"
+requires = ["b"]
+[[features]]
+id = "b"
+name = "B"
+requires = ["a"]
+"#;
+		let err = TemplateManifest::parse(raw).unwrap_err();
+		assert!(err.to_string().contains("cycle"));
+	}
+
+	#[test]
+	fn rejects_path_traversal() {
+		let raw = r#"
+schema_version = 1
+name = "x"
+[[features]]
+id = "a"
+name = "A"
+schema = ["../../etc/passwd"]
+"#;
+		let err = TemplateManifest::parse(raw).unwrap_err();
+		assert!(err.to_string().contains("unsafe file path"));
+	}
+}

--- a/crates/surrealkit/src/templates/mod.rs
+++ b/crates/surrealkit/src/templates/mod.rs
@@ -1,0 +1,56 @@
+//! Templates for `surrealkit init`.
+//!
+//! A template is a directory with a `template.toml` manifest plus `schema/`,
+//! `tests/suites/`, and `tests/fixtures/` subtrees. Templates can be bundled in
+//! the binary (under the repo's `/templates`), read from a local path, or cloned
+//! from a git URL. During `init` the user selects optional *features*; each
+//! feature contributes a set of files that are copied into the scaffolded project.
+
+mod emit;
+mod manifest;
+mod select;
+mod source;
+
+pub use select::InitOpts;
+
+use anyhow::Result;
+use surrealkit::scaffold;
+
+use emit::EmitPlan;
+use source::TemplateSource;
+
+/// Run `surrealkit init`: scaffold the base project and layer on the selected
+/// template features.
+pub fn run_init(folder: &str, opts: InitOpts) -> Result<()> {
+	// 1. Resolve where the template comes from.
+	let template_source = match &opts.from {
+		Some(from) => TemplateSource::from_arg(from)?,
+		None => TemplateSource::bundled(opts.template.as_deref())?,
+	};
+
+	// 2. Load + validate the manifest.
+	let manifest = source::load_manifest(&template_source)?;
+	let title = manifest.display_name.as_deref().unwrap_or(&manifest.name);
+	println!("Using template: {title}");
+	if let Some(desc) = &manifest.description {
+		println!("  {desc}");
+	}
+	println!();
+
+	// 3. Scaffold the base project tree (idempotent; skips existing files).
+	scaffold::scaffold(folder)?;
+
+	// 4. Resolve the dependency-closed feature set (interactive or from flags).
+	let feature_ids = select::resolve_features(&manifest, &opts)?;
+	if feature_ids.is_empty() {
+		println!("\nNo features selected — scaffolded a bare project.");
+		return Ok(());
+	}
+
+	// 5. Build the full emit plan (detects conflicts) and write it.
+	let plan = EmitPlan::build(folder, &manifest, &feature_ids, &template_source)?;
+	println!("\nAdding features: {}", feature_ids.join(", "));
+	plan.write(opts.force)?;
+
+	Ok(())
+}

--- a/crates/surrealkit/src/templates/select.rs
+++ b/crates/surrealkit/src/templates/select.rs
@@ -1,0 +1,194 @@
+use std::io::IsTerminal;
+
+use anyhow::Result;
+
+use super::manifest::TemplateManifest;
+
+/// Options driving `init`, parsed from the CLI.
+#[derive(Debug, Clone, Default)]
+pub struct InitOpts {
+	/// Bundled template name. Ignored when `from` is set.
+	pub template: Option<String>,
+	/// Git URL or local path to an external template.
+	pub from: Option<String>,
+	/// Explicit feature ids to enable (implies non-interactive).
+	pub feature: Vec<String>,
+	/// Scaffold the base project only; add no features.
+	pub minimal: bool,
+	/// Accept default features without prompting (non-interactive).
+	pub yes: bool,
+	/// Overwrite files that already exist.
+	pub force: bool,
+}
+
+/// Resolve the final, dependency-closed set of feature ids to emit.
+/// Honors the flag precedence and falls back to defaults when not on a TTY.
+pub fn resolve_features(manifest: &TemplateManifest, opts: &InitOpts) -> Result<Vec<String>> {
+	// 1. --minimal wins: no features.
+	if opts.minimal {
+		return Ok(Vec::new());
+	}
+
+	// 2. Explicit --feature flags.
+	if !opts.feature.is_empty() {
+		let closed = manifest.resolve_closure(&opts.feature)?;
+		announce_auto_added(manifest, &opts.feature, &closed);
+		return Ok(closed);
+	}
+
+	// 3. -y, or no TTY: take the defaults without prompting.
+	let interactive =
+		!opts.yes && std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
+
+	if !interactive {
+		if !opts.yes {
+			eprintln!(
+				"note: not a TTY; enabling default features (use --feature/--minimal/-y to control)"
+			);
+		}
+		let defaults = manifest.default_feature_ids();
+		return manifest.resolve_closure(&defaults);
+	}
+
+	// 4. Interactive multi-select.
+	prompt_features(manifest)
+}
+
+fn announce_auto_added(manifest: &TemplateManifest, requested: &[String], closed: &[String]) {
+	for id in closed {
+		if !requested.contains(id) {
+			// Find a requester that depends (directly) on this id, for a friendly note.
+			let by = manifest
+				.features
+				.iter()
+				.find(|f| requested.contains(&f.id) && f.requires.contains(id))
+				.map(|f| f.id.as_str());
+			match by {
+				Some(req) => println!("  + {id} (required by {req})"),
+				None => println!("  + {id} (dependency)"),
+			}
+		}
+	}
+}
+
+#[cfg(not(test))]
+fn prompt_features(manifest: &TemplateManifest) -> Result<Vec<String>> {
+	use inquire::MultiSelect;
+	use inquire::list_option::ListOption;
+
+	if manifest.features.is_empty() {
+		return Ok(Vec::new());
+	}
+
+	let labels: Vec<String> = manifest
+		.features
+		.iter()
+		.map(|f| match &f.description {
+			Some(d) => format!("{} — {}", f.name, d),
+			None => f.name.clone(),
+		})
+		.collect();
+
+	let defaults: Vec<usize> =
+		manifest.features.iter().enumerate().filter_map(|(i, f)| f.default.then_some(i)).collect();
+
+	let chosen: Vec<ListOption<String>> =
+		MultiSelect::new("Select features to add:", labels).with_default(&defaults).raw_prompt()?;
+
+	let selected: Vec<String> =
+		chosen.into_iter().map(|opt| manifest.features[opt.index].id.clone()).collect();
+
+	let closed = manifest.resolve_closure(&selected)?;
+	announce_auto_added(manifest, &selected, &closed);
+	Ok(closed)
+}
+
+// In tests there is no TTY; resolve_features never reaches the interactive path,
+// but provide a stub so the crate builds with `cfg(test)`.
+#[cfg(test)]
+fn prompt_features(manifest: &TemplateManifest) -> Result<Vec<String>> {
+	manifest.resolve_closure(&manifest.default_feature_ids())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// Mirrors the real template: two opt-in features, teams requires organizations.
+	fn manifest() -> TemplateManifest {
+		TemplateManifest::parse(
+			r#"
+schema_version = 1
+name = "t"
+[[features]]
+id = "organizations"
+name = "Organizations"
+default = false
+[[features]]
+id = "teams"
+name = "Teams"
+requires = ["organizations"]
+default = false
+"#,
+		)
+		.unwrap()
+	}
+
+	#[test]
+	fn minimal_yields_nothing() {
+		let opts = InitOpts {
+			minimal: true,
+			..Default::default()
+		};
+		assert!(resolve_features(&manifest(), &opts).unwrap().is_empty());
+	}
+
+	#[test]
+	fn explicit_feature_pulls_dependencies() {
+		let opts = InitOpts {
+			feature: vec!["teams".to_string()],
+			..Default::default()
+		};
+		let got = resolve_features(&manifest(), &opts).unwrap();
+		assert_eq!(got, vec!["organizations", "teams"]);
+	}
+
+	#[test]
+	fn yes_with_no_defaults_yields_nothing() {
+		// Features are opt-in: `-y` accepts the (empty) default set -> bare project.
+		let opts = InitOpts {
+			yes: true,
+			..Default::default()
+		};
+		assert!(resolve_features(&manifest(), &opts).unwrap().is_empty());
+	}
+
+	#[test]
+	fn yes_takes_default_features_when_present() {
+		let m = TemplateManifest::parse(
+			r#"
+schema_version = 1
+name = "t"
+[[features]]
+id = "organizations"
+name = "Organizations"
+default = true
+"#,
+		)
+		.unwrap();
+		let opts = InitOpts {
+			yes: true,
+			..Default::default()
+		};
+		assert_eq!(resolve_features(&m, &opts).unwrap(), vec!["organizations"]);
+	}
+
+	#[test]
+	fn unknown_feature_is_rejected() {
+		let opts = InitOpts {
+			feature: vec!["ghost".to_string()],
+			..Default::default()
+		};
+		assert!(resolve_features(&manifest(), &opts).is_err());
+	}
+}

--- a/crates/surrealkit/src/templates/source.rs
+++ b/crates/surrealkit/src/templates/source.rs
@@ -1,0 +1,251 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use tempfile::TempDir;
+
+use super::manifest::TemplateManifest;
+
+/// A single file embedded from the repo's `/templates` tree at compile time.
+/// `path` is relative to the templates root, e.g. `default/template.toml`.
+pub struct EmbeddedTemplateFile {
+	pub path: &'static str,
+	pub contents: &'static str,
+}
+
+// Embeds the entire `/templates` tree into the binary. `build.rs` generates the
+// `TEMPLATES` static (one `EmbeddedTemplateFile` per file).
+include!(concat!(env!("OUT_DIR"), "/embedded_templates.rs"));
+
+/// Read access to a template's files, independent of where they live.
+pub trait TemplateFiles {
+	/// The raw `template.toml` for this template.
+	fn read_manifest(&self) -> Result<String>;
+	/// Read a file by its manifest-relative path (e.g. `schema/user.surql`).
+	fn read_file(&self, rel: &str) -> Result<String>;
+}
+
+/// Where a template comes from.
+#[derive(Debug)]
+pub enum TemplateSource {
+	/// A template bundled in the binary, by name (e.g. `default`).
+	Bundled(String),
+	/// A template on the local filesystem, rooted at this directory.
+	Local(PathBuf),
+	/// A git working copy, kept alive for the lifetime of the source.
+	Git {
+		_tmp: TempDir,
+		root: PathBuf,
+	},
+}
+
+impl TemplateSource {
+	/// Resolve a `--from <url-or-path>` value (optionally `#rev`) into a source.
+	pub fn from_arg(from: &str) -> Result<Self> {
+		let looks_like_git = from.starts_with("http://")
+			|| from.starts_with("https://")
+			|| from.starts_with("git@")
+			|| from.starts_with("ssh://")
+			|| from.ends_with(".git");
+		if looks_like_git {
+			Self::from_git(from)
+		} else {
+			let path = PathBuf::from(from);
+			if !path.exists() {
+				bail!("template path '{}' does not exist", from);
+			}
+			Ok(TemplateSource::Local(path))
+		}
+	}
+
+	/// Clone a git template (shallow) into a temp dir. Supports `<url>#<rev>`
+	/// and `<url>#<rev>:<subdir>`.
+	fn from_git(spec: &str) -> Result<Self> {
+		let (url, rev, subdir) = parse_git_spec(spec);
+
+		which_git()?;
+
+		let tmp = TempDir::new().context("creating temp dir for git template")?;
+		let dest = tmp.path().join("repo");
+
+		let mut cmd = Command::new("git");
+		cmd.args(["clone", "--depth", "1"]);
+		if let Some(rev) = &rev {
+			cmd.args(["--branch", rev]);
+		}
+		cmd.arg(url).arg(&dest);
+
+		let status = cmd.status().context("running git clone")?;
+		if !status.success() {
+			bail!("git clone of '{}' failed", url);
+		}
+
+		let root = match &subdir {
+			Some(sub) => dest.join(sub),
+			None => dest,
+		};
+		if !root.exists() {
+			bail!("subdirectory '{}' not found in cloned template", subdir.unwrap_or_default());
+		}
+
+		Ok(TemplateSource::Git {
+			_tmp: tmp,
+			root,
+		})
+	}
+
+	/// The single bundled template name, or the default. Errors if `name` is
+	/// given but no such bundled template exists.
+	pub fn bundled(name: Option<&str>) -> Result<Self> {
+		let available = bundled_template_names();
+		let chosen = match name {
+			Some(n) => {
+				if !available.contains(n) {
+					bail!(
+						"no bundled template named '{}' (available: {})",
+						n,
+						available.into_iter().collect::<Vec<_>>().join(", ")
+					);
+				}
+				n.to_string()
+			}
+			None => {
+				if available.contains("default") {
+					"default".to_string()
+				} else if available.len() == 1 {
+					available.into_iter().next().expect("len checked == 1")
+				} else {
+					bail!(
+						"no default bundled template; pass --template (available: {})",
+						available.into_iter().collect::<Vec<_>>().join(", ")
+					);
+				}
+			}
+		};
+		Ok(TemplateSource::Bundled(chosen))
+	}
+}
+
+impl TemplateFiles for TemplateSource {
+	fn read_manifest(&self) -> Result<String> {
+		match self {
+			TemplateSource::Bundled(name) => {
+				let key = format!("{name}/template.toml");
+				bundled_file(&key)
+					.map(str::to_string)
+					.with_context(|| format!("bundled template '{name}' has no template.toml"))
+			}
+			TemplateSource::Local(root)
+			| TemplateSource::Git {
+				root,
+				..
+			} => read_local(root, "template.toml"),
+		}
+	}
+
+	fn read_file(&self, rel: &str) -> Result<String> {
+		match self {
+			TemplateSource::Bundled(name) => {
+				let key = format!("{name}/{rel}");
+				bundled_file(&key)
+					.map(str::to_string)
+					.with_context(|| format!("template file '{rel}' missing from bundled '{name}'"))
+			}
+			TemplateSource::Local(root)
+			| TemplateSource::Git {
+				root,
+				..
+			} => read_local(root, rel),
+		}
+	}
+}
+
+/// Names of bundled templates (top-level dirs under the embedded tree).
+pub fn bundled_template_names() -> BTreeSet<String> {
+	TEMPLATES.iter().filter_map(|f| f.path.split('/').next()).map(str::to_string).collect()
+}
+
+/// Load and validate the manifest for a source.
+pub fn load_manifest(source: &TemplateSource) -> Result<TemplateManifest> {
+	let raw = source.read_manifest()?;
+	TemplateManifest::parse(&raw)
+}
+
+fn bundled_file(key: &str) -> Option<&'static str> {
+	TEMPLATES.iter().find(|f| f.path == key).map(|f| f.contents)
+}
+
+fn read_local(root: &Path, rel: &str) -> Result<String> {
+	// Guard against traversal even though manifests are validated; `--from` may
+	// point at an untrusted tree.
+	if Path::new(rel).is_absolute() || rel.split(['/', '\\']).any(|c| c == "..") {
+		bail!("unsafe template path '{rel}'");
+	}
+	let path = root.join(rel);
+	std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))
+}
+
+fn which_git() -> Result<()> {
+	let ok =
+		Command::new("git").arg("--version").output().map(|o| o.status.success()).unwrap_or(false);
+	if !ok {
+		bail!("`git` was not found on PATH; install git or use a bundled template");
+	}
+	Ok(())
+}
+
+/// Parse `<url>[#<rev>[:<subdir>]]`.
+fn parse_git_spec(spec: &str) -> (&str, Option<String>, Option<String>) {
+	match spec.split_once('#') {
+		None => (spec, None, None),
+		Some((url, frag)) => match frag.split_once(':') {
+			Some((rev, sub)) => (url, Some(rev.to_string()), Some(sub.to_string())),
+			None => (url, Some(frag.to_string()), None),
+		},
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn bundled_default_template_present() {
+		let names = bundled_template_names();
+		assert!(names.contains("default"), "expected a bundled 'default' template: {names:?}");
+	}
+
+	#[test]
+	fn bundled_default_manifest_parses() {
+		let src = TemplateSource::bundled(Some("default")).unwrap();
+		let manifest = load_manifest(&src).unwrap();
+		assert_eq!(manifest.name, "default");
+		// Every file referenced by every feature must be present in the bundle.
+		for feature in &manifest.features {
+			for path in feature.all_paths() {
+				src.read_file(path)
+					.unwrap_or_else(|e| panic!("bundled file '{path}' unreadable: {e}"));
+			}
+		}
+	}
+
+	#[test]
+	fn unknown_bundled_name_errors() {
+		let err = TemplateSource::bundled(Some("ghost")).unwrap_err();
+		assert!(err.to_string().contains("no bundled template named 'ghost'"));
+	}
+
+	#[test]
+	fn parse_git_spec_variants() {
+		assert_eq!(parse_git_spec("https://x/y.git"), ("https://x/y.git", None, None));
+		assert_eq!(
+			parse_git_spec("https://x/y.git#main"),
+			("https://x/y.git", Some("main".into()), None)
+		);
+		assert_eq!(
+			parse_git_spec("https://x/y.git#v1:sub/dir"),
+			("https://x/y.git", Some("v1".into()), Some("sub/dir".into()))
+		);
+	}
+}

--- a/templates/default/schema/organization/employee_of.surql
+++ b/templates/default/schema/organization/employee_of.surql
@@ -1,0 +1,30 @@
+DEFINE TABLE OVERWRITE employee_of SCHEMAFULL
+	TYPE RELATION FROM user TO organization
+	PERMISSIONS
+		FOR select WHERE in = $auth
+			OR fn::organization::permissible($auth, out, "employees/view")
+		FOR create WHERE fn::organization::permissible($auth, out, "employees/manage")
+		FOR update, delete WHERE in != $auth
+			AND fn::organization::permissible($auth, out, "employees/manage");
+
+DEFINE FIELD OVERWRITE role ON employee_of TYPE record<organization_role>;
+
+DEFINE FIELD OVERWRITE title ON employee_of TYPE option<string>;
+
+DEFINE FIELD OVERWRITE status ON employee_of TYPE string
+	ASSERT $value IN ["invited", "active", "suspended", "resigned", "terminated"]
+	DEFAULT "active";
+
+DEFINE FIELD OVERWRITE joined_at ON employee_of TYPE datetime DEFAULT time::now();
+
+DEFINE INDEX OVERWRITE employee_of_by_account ON employee_of FIELDS in;
+DEFINE INDEX OVERWRITE employee_of_by_organization ON employee_of FIELDS out;
+DEFINE INDEX OVERWRITE employee_of_unique ON employee_of FIELDS in, out UNIQUE;
+
+DEFINE EVENT OVERWRITE guard_last_admin ON employee_of WHEN $event IN ["DELETE", "UPDATE"] THEN {
+	LET $org = IF $event = "DELETE" THEN $before.out ELSE $after.out END;
+	LET $admins = (SELECT VALUE id FROM employee_of
+		WHERE out = $org AND status = "active"
+			AND fn::organization::role::contains(role, "organization/manage"));
+	IF array::len($admins) = 0 { THROW "Organization needs at least one administrator" };
+};

--- a/templates/default/schema/organization/functions.surql
+++ b/templates/default/schema/organization/functions.surql
@@ -1,0 +1,33 @@
+DEFINE FUNCTION OVERWRITE fn::organization::role::contains($role: option<record<organization_role>>, $permission: string) {
+	IF $role == NONE { RETURN false };
+	LET $names = (SELECT VALUE permissions.name FROM ONLY $role);
+	IF $names == NONE { RETURN false };
+	RETURN $permission IN $names;
+};
+
+DEFINE FUNCTION OVERWRITE fn::organization::employee($account: option<record>, $organization: record<organization>) {
+	IF $account == NONE { RETURN false };
+	RETURN (SELECT VALUE id FROM employee_of
+		WHERE in = $account AND out = $organization AND status = "active" LIMIT 1) != [];
+};
+
+DEFINE FUNCTION OVERWRITE fn::account::organization::unit($account: record<user>, $organization: record<organization>) {
+	RETURN NONE;
+};
+
+DEFINE FUNCTION OVERWRITE fn::account::organization::teams($account: record<user>, $organization: record<organization>) {
+	RETURN [];
+};
+
+DEFINE FUNCTION OVERWRITE fn::organization::permissible($account: option<record<user>>, $organization: option<record<organization>>, $permission: string) {
+	IF $account == NONE OR $organization == NONE { RETURN false };
+
+	LET $roles = (SELECT VALUE role FROM employee_of
+		WHERE out = $organization AND in = $account AND status = "active");
+	FOR $role IN $roles {
+		IF fn::organization::role::contains($role, "organization/manage") { RETURN true };
+		IF fn::organization::role::contains($role, $permission) { RETURN true };
+	};
+
+	RETURN false;
+};

--- a/templates/default/schema/organization/organization.surql
+++ b/templates/default/schema/organization/organization.surql
@@ -1,0 +1,41 @@
+DEFINE TABLE OVERWRITE organization SCHEMAFULL
+	PERMISSIONS
+		FOR select WHERE fn::organization::employee($auth, id)
+		FOR create WHERE $auth != NONE
+		FOR update WHERE fn::organization::permissible($auth, id, "organization/manage")
+		FOR delete NONE;
+
+DEFINE FIELD OVERWRITE name ON organization TYPE string;
+
+DEFINE FIELD OVERWRITE legal_name ON organization TYPE option<string>;
+
+DEFINE FIELD OVERWRITE slug ON organization TYPE string
+	ASSERT $value = string::slug($value);
+
+DEFINE FIELD OVERWRITE logo ON organization TYPE option<string>;
+
+DEFINE FIELD OVERWRITE owner ON organization TYPE record<user>
+	DEFAULT $auth;
+
+DEFINE FIELD OVERWRITE created_at ON organization TYPE datetime
+	DEFAULT time::now();
+
+DEFINE INDEX OVERWRITE organization_slug_unique ON organization FIELDS slug UNIQUE;
+
+DEFINE EVENT OVERWRITE setup_organization ON organization WHEN $event = "CREATE" THEN {
+	LET $owner_role = CREATE ONLY organization_role SET
+		name = "Owner",
+		organization = $after.id,
+		description = "Owner of the organization",
+		kind = "system",
+		permissions = (SELECT VALUE id FROM organization_permission),
+		created_by = $after.owner;
+
+	LET $owner = $after.owner;
+	LET $org = $after.id;
+	RELATE $owner->employee_of->$org CONTENT {
+		role: $owner_role.id,
+		title: "Owner",
+		status: "active"
+	};
+};

--- a/templates/default/schema/organization/organization_invitation.surql
+++ b/templates/default/schema/organization/organization_invitation.surql
@@ -1,0 +1,47 @@
+DEFINE TABLE OVERWRITE organization_invitation SCHEMAFULL
+	PERMISSIONS
+		FOR create WHERE fn::organization::permissible($auth, organization_role.organization, "employees/manage")
+		FOR select, update WHERE created_by = $auth;
+
+DEFINE FIELD OVERWRITE organization_role ON organization_invitation TYPE record<organization_role>;
+
+DEFINE FIELD OVERWRITE email ON organization_invitation TYPE string
+	ASSERT string::is_email($value);
+
+DEFINE FIELD OVERWRITE token ON organization_invitation TYPE string;
+
+DEFINE FIELD OVERWRITE expires ON organization_invitation TYPE datetime;
+
+DEFINE FIELD OVERWRITE teams ON organization_invitation TYPE array<record> DEFAULT [];
+
+DEFINE FIELD OVERWRITE used_at ON organization_invitation TYPE option<datetime>;
+
+DEFINE FIELD OVERWRITE used_by ON organization_invitation TYPE option<record<user>>;
+
+DEFINE FIELD OVERWRITE created_by ON organization_invitation TYPE record<user>
+	DEFAULT $auth;
+
+DEFINE INDEX OVERWRITE organization_invitation_unique ON organization_invitation
+	FIELDS email, organization_role UNIQUE;
+DEFINE INDEX OVERWRITE organization_invitation_token ON organization_invitation
+	FIELDS token UNIQUE;
+
+DEFINE EVENT OVERWRITE on_accept ON organization_invitation
+	WHEN $before.used_at != $after.used_at OR $before.used_by != $after.used_by THEN {
+	IF $after.used_at = NONE OR $after.used_by = NONE { THROW "Invalid invitation" };
+
+	LET $account = $after.used_by;
+	LET $organization = (SELECT VALUE organization FROM ONLY $after.organization_role);
+
+	RELATE $account->employee_of->$organization CONTENT {
+		role: $after.organization_role,
+		status: "active"
+	};
+
+	LET $employee = (SELECT VALUE id FROM employee_of
+		WHERE in = $account AND out = $organization AND status = "active" LIMIT 1)[0];
+
+	FOR $team IN ($after.teams ?? []) {
+		RELATE $employee->member_of->$team;
+	};
+};

--- a/templates/default/schema/organization/organization_permission.surql
+++ b/templates/default/schema/organization/organization_permission.surql
@@ -1,0 +1,10 @@
+DEFINE TABLE OVERWRITE organization_permission SCHEMAFULL
+	PERMISSIONS
+		FOR select WHERE $auth != NONE
+		FOR create, update, delete NONE;
+
+DEFINE FIELD OVERWRITE name ON organization_permission TYPE string;
+
+DEFINE FIELD OVERWRITE description ON organization_permission TYPE option<string>;
+
+DEFINE INDEX OVERWRITE organization_permission_name ON organization_permission FIELDS name UNIQUE;

--- a/templates/default/schema/organization/organization_role.surql
+++ b/templates/default/schema/organization/organization_role.surql
@@ -1,0 +1,25 @@
+DEFINE TABLE OVERWRITE organization_role SCHEMAFULL
+	PERMISSIONS
+		FOR select WHERE fn::organization::permissible($auth, organization, "roles/read")
+		FOR create, update, delete WHERE fn::organization::permissible($auth, organization, "roles/manage");
+
+DEFINE FIELD OVERWRITE name ON organization_role TYPE string;
+
+DEFINE FIELD OVERWRITE organization ON organization_role TYPE record<organization>
+	REFERENCE ON DELETE CASCADE;
+
+DEFINE FIELD OVERWRITE description ON organization_role TYPE option<string>;
+
+DEFINE FIELD OVERWRITE kind ON organization_role TYPE string
+	ASSERT $value IN ["system", "organization"]
+	DEFAULT "organization";
+
+DEFINE FIELD OVERWRITE sort_order ON organization_role TYPE number DEFAULT 0;
+
+DEFINE FIELD OVERWRITE permissions ON organization_role TYPE array<record<organization_permission>>
+	DEFAULT [];
+
+DEFINE FIELD OVERWRITE created_by ON organization_role TYPE option<record<user>>;
+
+DEFINE INDEX OVERWRITE organization_role_unique ON organization_role
+	FIELDS organization, name UNIQUE;

--- a/templates/default/schema/subsidiaries/functions.surql
+++ b/templates/default/schema/subsidiaries/functions.surql
@@ -1,0 +1,26 @@
+DEFINE FUNCTION OVERWRITE fn::organization::permissible($account: option<record<user>>, $organization: option<record<organization>>, $permission: string) {
+	IF $account == NONE OR $organization == NONE { RETURN false };
+
+	LET $roles = (SELECT VALUE role FROM employee_of
+		WHERE out = $organization AND in = $account AND status = "active");
+	FOR $role IN $roles {
+		IF fn::organization::role::contains($role, "organization/manage") { RETURN true };
+		IF fn::organization::role::contains($role, $permission) { RETURN true };
+	};
+
+	LET $parents = (SELECT VALUE in FROM has_subsidiary WHERE out = $organization AND status = "active");
+	FOR $parent IN $parents {
+		LET $teams = fn::account::organization::teams($account, $parent);
+		LET $unit = fn::account::organization::unit($account, $parent);
+		LET $grants = SELECT role FROM organization_delegation_grant
+			WHERE in = $parent AND out = $organization
+				AND (subject = $account OR subject IN $teams
+					OR ($unit != NONE AND fn::organization::unit::descendant($unit, subject)));
+		FOR $g IN $grants {
+			IF fn::organization::role::contains($g.role, "organization/manage")
+				OR fn::organization::role::contains($g.role, $permission) { RETURN true };
+		};
+	};
+
+	RETURN false;
+};

--- a/templates/default/schema/subsidiaries/has_subsidiary.surql
+++ b/templates/default/schema/subsidiaries/has_subsidiary.surql
@@ -1,0 +1,15 @@
+DEFINE TABLE OVERWRITE has_subsidiary SCHEMAFULL
+	TYPE RELATION FROM organization TO organization
+	PERMISSIONS
+		FOR select WHERE fn::organization::permissible($auth, in, "organization/subsidiaries")
+			OR fn::organization::permissible($auth, out, "organization/subsidiaries")
+		FOR create, update, delete WHERE fn::organization::permissible($auth, in, "organization/subsidiaries")
+			AND fn::organization::permissible($auth, out, "organization/subsidiaries");
+
+DEFINE FIELD OVERWRITE status ON has_subsidiary TYPE string
+	ASSERT $value IN ["active", "inactive"]
+	DEFAULT "active";
+
+DEFINE INDEX OVERWRITE has_subsidiary_by_parent ON has_subsidiary FIELDS in;
+DEFINE INDEX OVERWRITE has_subsidiary_by_child ON has_subsidiary FIELDS out;
+DEFINE INDEX OVERWRITE has_subsidiary_unique ON has_subsidiary FIELDS in, out UNIQUE;

--- a/templates/default/schema/subsidiaries/organization_delegation_grant.surql
+++ b/templates/default/schema/subsidiaries/organization_delegation_grant.surql
@@ -1,0 +1,29 @@
+DEFINE TABLE OVERWRITE organization_delegation_grant SCHEMAFULL
+	TYPE RELATION FROM organization TO organization
+	PERMISSIONS
+		FOR select WHERE fn::organization::permissible($auth, in, "organization/subsidiaries")
+		FOR create, update, delete WHERE fn::organization::permissible($auth, in, "organization/subsidiaries")
+			AND fn::organization::permissible($auth, out, "organization/subsidiaries");
+
+DEFINE FIELD OVERWRITE subject ON organization_delegation_grant TYPE record;
+
+DEFINE FIELD OVERWRITE role ON organization_delegation_grant TYPE record<organization_role>;
+
+DEFINE FIELD OVERWRITE scope ON organization_delegation_grant TYPE string
+	ASSERT $value IN ["organization", "unit"]
+	DEFAULT "organization";
+
+DEFINE FIELD OVERWRITE unit ON organization_delegation_grant TYPE option<record>;
+
+DEFINE FIELD OVERWRITE created_at ON organization_delegation_grant TYPE datetime DEFAULT time::now();
+
+DEFINE EVENT OVERWRITE grant_validation ON organization_delegation_grant
+	WHEN $event = "CREATE" OR $event = "UPDATE" THEN {
+	LET $relation = (SELECT VALUE id FROM has_subsidiary
+		WHERE in = $after.in AND out = $after.out AND status = "active");
+	IF $relation = NONE OR array::len($relation) = 0 { THROW "UNAUTHORIZED_SUBSIDIARY" };
+
+	IF $after.role.organization != $after.out { THROW "DELEGATED_ROLE_NOT_IN_SUBSIDIARY" };
+
+	IF $after.scope = "unit" AND $after.unit = NONE { THROW "DELEGATED_UNIT_SCOPE_NOT_PRESENT" };
+};

--- a/templates/default/schema/team/functions.surql
+++ b/templates/default/schema/team/functions.surql
@@ -1,0 +1,21 @@
+DEFINE FUNCTION OVERWRITE fn::account::organization::teams($account: record<user>, $organization: record<organization>) {
+	LET $employees = (SELECT VALUE id FROM employee_of WHERE in = $account AND out = $organization);
+	RETURN (SELECT VALUE out FROM member_of WHERE in IN $employees AND out.organization = $organization);
+};
+
+DEFINE FUNCTION OVERWRITE fn::team::get_role($account: record<user>, $team: record<team>) {
+	LET $employees = (SELECT VALUE id FROM employee_of WHERE in = $account AND status = "active");
+	RETURN (SELECT VALUE role FROM member_of WHERE in IN $employees AND out = $team LIMIT 1)[0];
+};
+
+DEFINE FUNCTION OVERWRITE fn::team::member_of($account: option<record<user>>, $team: option<record<team>>, $role: option<string>) {
+	IF $account == NONE OR $team == NONE { RETURN false };
+	LET $current = fn::team::get_role($account, $team);
+	IF $current == NONE { RETURN false };
+	LET $required = IF $role == "maintainer" THEN ["maintainer"] ELSE ["maintainer", "member"] END;
+	RETURN $current IN $required;
+};
+
+DEFINE FUNCTION OVERWRITE fn::team::members($team: record<team>) {
+	RETURN SELECT in AS employee, in.in AS account, role, joined_at FROM member_of WHERE out = $team;
+};

--- a/templates/default/schema/team/member_of.surql
+++ b/templates/default/schema/team/member_of.surql
@@ -1,0 +1,17 @@
+DEFINE TABLE OVERWRITE member_of SCHEMAFULL
+	TYPE RELATION FROM employee_of TO team
+	PERMISSIONS
+		FOR select WHERE in.in = $auth
+			OR fn::organization::permissible($auth, out.organization, "team/view")
+		FOR create, update, delete WHERE fn::organization::permissible($auth, out.organization, "team/manage")
+			OR fn::team::member_of($auth, out, "maintainer");
+
+DEFINE FIELD OVERWRITE role ON member_of TYPE string
+	ASSERT $value IN ["maintainer", "member"]
+	DEFAULT "member";
+
+DEFINE FIELD OVERWRITE joined_at ON member_of TYPE datetime DEFAULT time::now();
+
+DEFINE INDEX OVERWRITE member_of_by_employee ON member_of FIELDS in;
+DEFINE INDEX OVERWRITE member_of_by_team ON member_of FIELDS out;
+DEFINE INDEX OVERWRITE member_of_unique ON member_of FIELDS in, out UNIQUE;

--- a/templates/default/schema/team/team.surql
+++ b/templates/default/schema/team/team.surql
@@ -1,0 +1,23 @@
+DEFINE TABLE OVERWRITE team SCHEMAFULL
+	PERMISSIONS
+		FOR select WHERE fn::team::member_of($auth, id, NONE)
+			OR fn::organization::permissible($auth, organization, "team/view")
+		FOR create WHERE fn::organization::permissible($auth, organization, "team/create")
+			OR fn::organization::permissible($auth, organization, "team/manage")
+		FOR update WHERE fn::organization::permissible($auth, organization, "team/update")
+			OR fn::organization::permissible($auth, organization, "team/manage")
+		FOR delete WHERE fn::organization::permissible($auth, organization, "team/delete")
+			OR fn::organization::permissible($auth, organization, "team/manage");
+
+DEFINE FIELD OVERWRITE name ON team TYPE string;
+
+DEFINE FIELD OVERWRITE parent ON team TYPE option<record<team>>;
+
+DEFINE FIELD OVERWRITE organization ON team TYPE record<organization>
+	REFERENCE ON DELETE CASCADE;
+
+DEFINE FIELD OVERWRITE created_at ON team TYPE datetime DEFAULT time::now();
+
+DEFINE INDEX OVERWRITE team_org_name_unique ON team FIELDS organization, name UNIQUE;
+
+DEFINE FIELD OVERWRITE teams ON organization COMPUTED <~team;

--- a/templates/default/schema/units/functions.surql
+++ b/templates/default/schema/units/functions.surql
@@ -1,0 +1,20 @@
+DEFINE FUNCTION OVERWRITE fn::organization::unit::path($unit: record<organization_unit>) {
+	LET $x = (SELECT organization, parent FROM ONLY $unit);
+	IF $x == NONE { RETURN "" };
+	IF $x.parent == NONE { RETURN "/" + record::id($unit) + "/" };
+	LET $parent_path = (SELECT VALUE path FROM ONLY $x.parent);
+	IF $parent_path == NONE OR $parent_path == "" { RETURN "" };
+	RETURN $parent_path + record::id($unit) + "/";
+};
+
+DEFINE FUNCTION OVERWRITE fn::organization::unit::descendant($child: record<organization_unit>, $parent: record<organization_unit>) {
+	LET $c = (SELECT VALUE path FROM ONLY $child);
+	LET $a = (SELECT VALUE path FROM ONLY $parent);
+	IF $c == NONE OR $a == NONE { RETURN false };
+	RETURN string::starts_with($c, $a);
+};
+
+DEFINE FUNCTION OVERWRITE fn::account::organization::unit($account: record<user>, $organization: record<organization>) {
+	RETURN (SELECT VALUE unit FROM ONLY employee_of
+		WHERE in = $account AND out = $organization AND status = "active");
+};

--- a/templates/default/schema/units/organization_unit.surql
+++ b/templates/default/schema/units/organization_unit.surql
@@ -1,0 +1,40 @@
+DEFINE TABLE OVERWRITE organization_unit SCHEMAFULL
+	PERMISSIONS
+		FOR select WHERE fn::organization::employee($auth, organization)
+		FOR create, update, delete WHERE fn::organization::permissible($auth, organization, "organization/manage");
+
+DEFINE FIELD OVERWRITE organization ON organization_unit TYPE record<organization>
+	REFERENCE ON DELETE CASCADE;
+
+DEFINE FIELD OVERWRITE parent ON organization_unit TYPE option<record<organization_unit>>;
+
+DEFINE FIELD OVERWRITE name ON organization_unit TYPE string;
+
+DEFINE FIELD OVERWRITE path ON organization_unit TYPE string DEFAULT "/";
+
+DEFINE FIELD OVERWRITE kind ON organization_unit TYPE string
+	ASSERT $value IN ["department", "region"]
+	DEFAULT "department";
+
+DEFINE FIELD OVERWRITE created_at ON organization_unit TYPE datetime DEFAULT time::now();
+
+DEFINE INDEX OVERWRITE organization_unit_by_org ON organization_unit FIELDS organization;
+DEFINE INDEX OVERWRITE organization_unit_path ON organization_unit FIELDS organization, path UNIQUE;
+
+DEFINE FIELD OVERWRITE unit ON employee_of TYPE option<record<organization_unit>>
+	ASSERT $value == NONE OR $value.organization = out;
+
+DEFINE EVENT OVERWRITE set_path ON organization_unit
+	WHEN $event = "CREATE" OR $event = "UPDATE" THEN {
+	UPDATE organization_unit SET path = fn::organization::unit::path($value.id) WHERE id = $value.id;
+
+	IF $event = "UPDATE" AND $before.parent != $after.parent {
+		LET $old = $before.path;
+		LET $new = (SELECT VALUE path FROM ONLY $value.id);
+		UPDATE organization_unit
+			SET path = string::replace(path, $old, $new)
+			WHERE organization = $value.organization
+				AND string::starts_with(path, $old)
+				AND id != $value.id;
+	};
+};

--- a/templates/default/schema/user.surql
+++ b/templates/default/schema/user.surql
@@ -1,0 +1,14 @@
+DEFINE TABLE OVERWRITE user SCHEMAFULL
+	PERMISSIONS
+		FOR select WHERE id = $auth.id
+		FOR create, update, delete NONE;
+
+DEFINE FIELD OVERWRITE email ON user TYPE string
+	ASSERT string::is_email($value);
+
+DEFINE FIELD OVERWRITE name ON user TYPE option<string>;
+
+DEFINE FIELD OVERWRITE created_at ON user TYPE datetime
+	DEFAULT time::now();
+
+DEFINE INDEX OVERWRITE user_email_unique ON user FIELDS email UNIQUE;

--- a/templates/default/seed/organization_permissions.surql
+++ b/templates/default/seed/organization_permissions.surql
@@ -1,0 +1,7 @@
+UPSERT organization_permission:organization_manage       SET name = "organization/manage",       description = "Full control of the organization";
+UPSERT organization_permission:organization_subsidiaries SET name = "organization/subsidiaries", description = "Manage subsidiaries and delegations";
+UPSERT organization_permission:employees_view            SET name = "employees/view",            description = "View employees";
+UPSERT organization_permission:employees_manage          SET name = "employees/manage",          description = "Invite, update, and remove employees";
+UPSERT organization_permission:roles_read                SET name = "roles/read",                description = "View roles";
+UPSERT organization_permission:roles_manage              SET name = "roles/manage",              description = "Create, update, and delete roles";
+UPSERT organization_permission:roles_assign              SET name = "roles/assign",              description = "Assign roles to employees";

--- a/templates/default/seed/team_permissions.surql
+++ b/templates/default/seed/team_permissions.surql
@@ -1,0 +1,5 @@
+UPSERT organization_permission:team_view   SET name = "team/view",   description = "View teams";
+UPSERT organization_permission:team_create SET name = "team/create", description = "Create teams";
+UPSERT organization_permission:team_update SET name = "team/update", description = "Update teams";
+UPSERT organization_permission:team_delete SET name = "team/delete", description = "Delete teams";
+UPSERT organization_permission:team_manage SET name = "team/manage", description = "Manage all teams and their members";

--- a/templates/default/template.toml
+++ b/templates/default/template.toml
@@ -1,0 +1,61 @@
+schema_version = 1
+name = "default"
+display_name = "SurrealKit starter"
+description = "Optional building blocks for a new SurrealDB project"
+
+[[features]]
+id = "organizations"
+name = "Organizations"
+description = "Orgs, roles, per-app permissions, employees, and invitations"
+default = false
+schema = [
+	"schema/user.surql",
+	"schema/organization/functions.surql",
+	"schema/organization/organization.surql",
+	"schema/organization/organization_permission.surql",
+	"schema/organization/organization_role.surql",
+	"schema/organization/employee_of.surql",
+	"schema/organization/organization_invitation.surql",
+]
+seed = ["seed/organization_permissions.surql"]
+suites = ["tests/suites/organization.toml"]
+fixtures = ["tests/fixtures/organization_seed.surql"]
+
+[[features]]
+id = "teams"
+name = "Teams"
+description = "Teams with per-member roles (maintainer/member)"
+default = false
+requires = ["organizations"]
+schema = [
+	"schema/team/team.surql",
+	"schema/team/member_of.surql",
+	"schema/team/functions.surql",
+]
+seed = ["seed/team_permissions.surql"]
+suites = ["tests/suites/teams.toml"]
+
+[[features]]
+id = "units"
+name = "Organization units"
+description = "Departments/regions in a hierarchy, with unit-scoped permissions"
+default = false
+requires = ["organizations"]
+schema = [
+	"schema/units/organization_unit.surql",
+	"schema/units/functions.surql",
+]
+suites = ["tests/suites/units.toml"]
+
+[[features]]
+id = "subsidiaries"
+name = "Subsidiaries & delegation"
+description = "Parent/child orgs with cross-org delegated permissions"
+default = false
+requires = ["organizations"]
+schema = [
+	"schema/subsidiaries/has_subsidiary.surql",
+	"schema/subsidiaries/organization_delegation_grant.surql",
+	"schema/subsidiaries/functions.surql",
+]
+suites = ["tests/suites/subsidiaries.toml"]

--- a/templates/default/tests/fixtures/organization_seed.surql
+++ b/templates/default/tests/fixtures/organization_seed.surql
@@ -1,0 +1,16 @@
+CREATE user:alice SET email = "alice@example.com", name = "Alice";
+CREATE user:bob   SET email = "bob@example.com",   name = "Bob";
+CREATE user:carol SET email = "carol@example.com", name = "Carol";
+
+CREATE organization:acme SET name = "Acme", slug = "acme", owner = user:alice;
+
+LET $member_role = CREATE ONLY organization_role SET
+	name = "Member",
+	organization = organization:acme,
+	description = "Standard member",
+	permissions = [organization_permission:employees_view];
+RELATE user:bob->employee_of->organization:acme CONTENT {
+	role: $member_role.id,
+	title: "Member",
+	status: "active"
+};

--- a/templates/default/tests/suites/organization.toml
+++ b/templates/default/tests/suites/organization.toml
@@ -1,0 +1,101 @@
+name = "organization"
+tags = ["organization", "auth"]
+
+[[fixtures]]
+name = "organization_seed"
+actor = "root"
+file = "../fixtures/organization_seed.surql"
+
+[[cases]]
+name = "metadata_defines_org_model"
+kind = "schema_metadata"
+actor = "root"
+sql = "INFO FOR DB;"
+contains = [
+  "organization",
+  "organization_role",
+  "organization_permission",
+  "employee_of",
+  "fn::organization::permissible",
+]
+
+[[cases]]
+name = "owner_is_provisioned_with_system_role"
+kind = "sql_expect"
+actor = "root"
+sql = "RETURN (SELECT VALUE name FROM organization_role WHERE organization = organization:acme AND kind = 'system')[0];"
+allow = true
+
+[[cases.assertions]]
+path = ""
+equals = "Owner"
+
+[[cases]]
+name = "owner_is_superuser"
+kind = "sql_expect"
+actor = "root"
+sql = "RETURN fn::organization::permissible(user:alice, organization:acme, 'roles/manage');"
+allow = true
+
+[[cases.assertions]]
+path = ""
+equals = true
+
+[[cases]]
+name = "member_has_granted_permission"
+kind = "sql_expect"
+actor = "root"
+sql = "RETURN fn::organization::permissible(user:bob, organization:acme, 'employees/view');"
+allow = true
+
+[[cases.assertions]]
+path = ""
+equals = true
+
+[[cases]]
+name = "member_lacks_ungranted_permission"
+kind = "sql_expect"
+actor = "root"
+sql = "RETURN fn::organization::permissible(user:bob, organization:acme, 'employees/manage');"
+allow = true
+
+[[cases.assertions]]
+path = ""
+equals = false
+
+[[cases]]
+name = "non_employee_is_denied"
+kind = "sql_expect"
+actor = "root"
+sql = "RETURN fn::organization::permissible(user:carol, organization:acme, 'employees/view');"
+allow = true
+
+[[cases.assertions]]
+path = ""
+equals = false
+
+[[cases]]
+name = "employee_helper_recognises_owner"
+kind = "sql_expect"
+actor = "root"
+sql = "RETURN fn::organization::employee(user:alice, organization:acme);"
+allow = true
+
+[[cases.assertions]]
+path = ""
+equals = true
+
+[[cases]]
+name = "invitation_accept_creates_employee"
+kind = "schema_behavior"
+actor = "root"
+setup_sql = [
+  "LET $role = (SELECT VALUE id FROM organization_role WHERE organization = organization:acme AND name = 'Member' LIMIT 1)[0]; CREATE organization_invitation:inv_carol SET organization_role = $role, email = 'carol@example.com', token = 'tok-carol', expires = time::now() + 7d, created_by = user:alice;",
+]
+action_sql = "UPDATE organization_invitation:inv_carol SET used_at = time::now(), used_by = user:carol;"
+verify_sql = "RETURN fn::organization::employee(user:carol, organization:acme);"
+expect_success = true
+
+[[cases.assertions]]
+path = ""
+equals = true

--- a/templates/default/tests/suites/subsidiaries.toml
+++ b/templates/default/tests/suites/subsidiaries.toml
@@ -1,0 +1,47 @@
+name = "subsidiaries"
+tags = ["organization", "subsidiaries"]
+
+[[fixtures]]
+name = "organization_seed"
+actor = "root"
+file = "../fixtures/organization_seed.surql"
+
+[[cases]]
+name = "metadata_defines_subsidiary_model"
+kind = "schema_metadata"
+actor = "root"
+sql = "INFO FOR DB;"
+contains = ["has_subsidiary", "organization_delegation_grant"]
+
+[[cases]]
+name = "delegated_role_grants_permission_in_subsidiary"
+kind = "schema_behavior"
+actor = "root"
+setup_sql = [
+  "CREATE organization:sub SET name = 'Sub', slug = 'sub', owner = user:alice;",
+  "RELATE organization:acme->has_subsidiary->organization:sub SET status = 'active';",
+  "LET $subrole = (SELECT VALUE id FROM organization_role WHERE organization = organization:sub AND name = 'Owner' LIMIT 1)[0]; RELATE organization:acme->organization_delegation_grant->organization:sub SET subject = user:bob, role = $subrole, scope = 'organization';",
+]
+action_sql = "RETURN fn::organization::permissible(user:bob, organization:sub, 'organization/manage');"
+verify_sql = "RETURN fn::organization::permissible(user:bob, organization:sub, 'organization/manage');"
+expect_success = true
+
+[[cases.assertions]]
+path = ""
+equals = true
+
+[[cases]]
+name = "without_delegation_permission_is_denied"
+kind = "schema_behavior"
+actor = "root"
+setup_sql = [
+  "CREATE organization:sub2 SET name = 'Sub Two', slug = 'sub-two', owner = user:alice;",
+  "RELATE organization:acme->has_subsidiary->organization:sub2 SET status = 'active';",
+]
+action_sql = "RETURN fn::organization::permissible(user:bob, organization:sub2, 'organization/manage');"
+verify_sql = "RETURN fn::organization::permissible(user:bob, organization:sub2, 'organization/manage');"
+expect_success = true
+
+[[cases.assertions]]
+path = ""
+equals = false

--- a/templates/default/tests/suites/teams.toml
+++ b/templates/default/tests/suites/teams.toml
@@ -1,0 +1,92 @@
+name = "teams"
+tags = ["organization", "teams"]
+
+[[fixtures]]
+name = "organization_seed"
+actor = "root"
+file = "../fixtures/organization_seed.surql"
+
+[[cases]]
+name = "metadata_defines_team_model"
+kind = "schema_metadata"
+actor = "root"
+sql = "INFO FOR DB;"
+contains = ["team", "member_of", "fn::team::member_of"]
+
+[[cases]]
+name = "team_member_role_is_recorded"
+kind = "schema_behavior"
+actor = "root"
+setup_sql = [
+  "CREATE team:eng SET name = 'Engineering', organization = organization:acme;",
+  "LET $emp = (SELECT VALUE id FROM employee_of WHERE in = user:bob AND out = organization:acme LIMIT 1)[0]; RELATE $emp->member_of->team:eng SET role = 'maintainer';",
+]
+action_sql = "RETURN fn::team::get_role(user:bob, team:eng);"
+verify_sql = "RETURN fn::team::get_role(user:bob, team:eng);"
+expect_success = true
+
+[[cases.assertions]]
+path = ""
+equals = "maintainer"
+
+[[cases]]
+name = "maintainer_satisfies_member_requirement"
+kind = "schema_behavior"
+actor = "root"
+setup_sql = [
+  "CREATE team:design SET name = 'Design', organization = organization:acme;",
+  "LET $emp = (SELECT VALUE id FROM employee_of WHERE in = user:bob AND out = organization:acme LIMIT 1)[0]; RELATE $emp->member_of->team:design SET role = 'maintainer';",
+]
+action_sql = "RETURN fn::team::member_of(user:bob, team:design, 'member');"
+verify_sql = "RETURN fn::team::member_of(user:bob, team:design, 'member');"
+expect_success = true
+
+[[cases.assertions]]
+path = ""
+equals = true
+
+[[cases]]
+name = "non_member_is_not_in_team"
+kind = "schema_behavior"
+actor = "root"
+setup_sql = [
+  "CREATE team:ops SET name = 'Ops', organization = organization:acme;",
+]
+action_sql = "RETURN fn::team::member_of(user:carol, team:ops, NONE);"
+verify_sql = "RETURN fn::team::member_of(user:carol, team:ops, NONE);"
+expect_success = true
+
+[[cases.assertions]]
+path = ""
+equals = false
+
+[[cases]]
+name = "team_members_lists_with_roles"
+kind = "schema_behavior"
+actor = "root"
+setup_sql = [
+  "CREATE team:sales SET name = 'Sales', organization = organization:acme;",
+  "LET $emp = (SELECT VALUE id FROM employee_of WHERE in = user:bob AND out = organization:acme LIMIT 1)[0]; RELATE $emp->member_of->team:sales SET role = 'member';",
+]
+action_sql = "RETURN fn::team::members(team:sales);"
+verify_sql = "RETURN fn::team::members(team:sales);"
+expect_success = true
+
+[[cases.assertions]]
+path = "0.role"
+exists = true
+
+[[cases]]
+name = "organization_exposes_teams"
+kind = "schema_behavior"
+actor = "root"
+setup_sql = [
+  "CREATE team:marketing SET name = 'Marketing', organization = organization:acme;",
+]
+action_sql = "RETURN array::len((SELECT VALUE teams FROM ONLY organization:acme)) > 0;"
+verify_sql = "RETURN array::len((SELECT VALUE teams FROM ONLY organization:acme)) > 0;"
+expect_success = true
+
+[[cases.assertions]]
+path = ""
+equals = true

--- a/templates/default/tests/suites/units.toml
+++ b/templates/default/tests/suites/units.toml
@@ -1,0 +1,62 @@
+name = "units"
+tags = ["organization", "units"]
+
+[[fixtures]]
+name = "organization_seed"
+actor = "root"
+file = "../fixtures/organization_seed.surql"
+
+[[cases]]
+name = "metadata_defines_unit_model"
+kind = "schema_metadata"
+actor = "root"
+sql = "INFO FOR DB;"
+contains = ["organization_unit", "fn::organization::unit::descendant"]
+
+[[cases]]
+name = "child_unit_is_descendant_of_root"
+kind = "schema_behavior"
+actor = "root"
+setup_sql = [
+  "CREATE organization_unit:root SET name = 'Root', organization = organization:acme;",
+  "CREATE organization_unit:eng SET name = 'Engineering', organization = organization:acme, parent = organization_unit:root;",
+]
+action_sql = "RETURN fn::organization::unit::descendant(organization_unit:eng, organization_unit:root);"
+verify_sql = "RETURN fn::organization::unit::descendant(organization_unit:eng, organization_unit:root);"
+expect_success = true
+
+[[cases.assertions]]
+path = ""
+equals = true
+
+[[cases]]
+name = "unrelated_units_are_not_descendants"
+kind = "schema_behavior"
+actor = "root"
+setup_sql = [
+  "CREATE organization_unit:sales SET name = 'Sales', organization = organization:acme;",
+  "CREATE organization_unit:ops SET name = 'Ops', organization = organization:acme;",
+]
+action_sql = "RETURN fn::organization::unit::descendant(organization_unit:sales, organization_unit:ops);"
+verify_sql = "RETURN fn::organization::unit::descendant(organization_unit:sales, organization_unit:ops);"
+expect_success = true
+
+[[cases.assertions]]
+path = ""
+equals = false
+
+[[cases]]
+name = "employee_can_be_assigned_a_unit"
+kind = "schema_behavior"
+actor = "root"
+setup_sql = [
+  "CREATE organization_unit:finance SET name = 'Finance', organization = organization:acme;",
+  "UPDATE employee_of SET unit = organization_unit:finance WHERE in = user:bob AND out = organization:acme;",
+]
+action_sql = "RETURN fn::account::organization::unit(user:bob, organization:acme);"
+verify_sql = "RETURN record::tb(fn::account::organization::unit(user:bob, organization:acme));"
+expect_success = true
+
+[[cases.assertions]]
+path = ""
+equals = "organization_unit"


### PR DESCRIPTION
Reworks `surrealkit init` so it scaffolds from a template and lets you pick optional features to add, instead of always emitting a fixed empty project.

### Template system

- Templates are bundled under `/templates` and embedded into the binary at build time (via `build.rs`), so they work for `cargo binstall`. You can also pass your own with `--from <git-url|local-path>`, which uses `git clone --depth 1` and supports `#rev` and `#rev:subdir`.
- A `template.toml` manifest declares features. Each feature contributes files across four destinations: `schema/`, `seed/`, `tests/suites/`, and `tests/fixtures/`. The manifest is validated for schema version, unique ids, resolvable `requires`, dependency cycles, and path traversal.
- Selection is an interactive multi-select (`inquire`) with non-interactive fallbacks: `--feature <id>` (repeatable), `--minimal`, `-y`, and an automatic defaults path when stdout is not a TTY. Dependencies close transitively, so picking a feature pulls in what it requires.
- Emission is all or nothing. The full file plan is built and checked for conflicts before anything is written, and existing files are skipped unless `--force`. The module lives in the binary (`src/templates/`), not the public library API.

### Default template: Organizations and Teams

An opt-in org/auth model split into four features (`organizations` is the base; `teams`, `units`, and `subsidiaries` each require it):

- **Organizations**: orgs, a per-app `organization_permission` catalog, roles that bundle permissions, employees (`employee_of`), and token-based invitations. Creating an org auto-provisions an "Owner" role and employee.
- **Teams**: `team` plus `member_of` with per-member roles (maintainer/member).
- **Organization units**: department/region hierarchy with a materialized path.
- **Subsidiaries and delegation**: parent/child orgs with cross-org delegated permissions.

`fn::organization::permissible(account, org, "resource/action")` is the central check, where `organization/manage` acts as a superuser grant. It takes an explicit account so it is testable as the root actor, while table `PERMISSIONS` pass `$auth`. Cross-feature coupling is handled with base stubs that the optional features override, so the base `permissible` never references a table that is not installed.