### PR TITLE
Add embedded instance support and seed tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.9.4",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +571,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +606,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -640,6 +677,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -760,6 +808,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1294,6 +1351,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1611,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1626,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "guardian"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "h2"
@@ -2115,6 +2194,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c00403deb17c3221a1fe4fb571b9ed0370b3dcd116553c77fa294a3d918699"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,10 +2351,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2321,6 +2427,15 @@ checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -2406,6 +2521,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,6 +2610,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978fe6e6ebc0bf53de533cd456ca2d9de13de13856eda1518a285d7705a213af"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2916,6 +3047,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -4025,6 +4162,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4257,8 +4400,10 @@ dependencies = [
  "subtle",
  "surrealdb-collections",
  "surrealdb-protocol",
+ "surrealdb-rocksdb",
  "surrealdb-strand",
  "surrealdb-types",
+ "surrealkv",
  "surrealmx",
  "sysinfo",
  "tempfile",
@@ -4274,6 +4419,21 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasmtimer",
  "web-time",
+]
+
+[[package]]
+name = "surrealdb-librocksdb-sys"
+version = "0.18.3+11.0.0-4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b82a18c7fa4b57206784a1a31e7b942ae1d3e24493e0c733019a409b2b4bea"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -4298,6 +4458,16 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "uuid",
+]
+
+[[package]]
+name = "surrealdb-rocksdb"
+version = "0.24.0-surreal.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e8c3a004982458af159bcbf369e41663d538cd4a291a49c0d4a2fb373cbb7e"
+dependencies = [
+ "libc",
+ "surrealdb-librocksdb-sys",
 ]
 
 [[package]]
@@ -4388,6 +4558,35 @@ dependencies = [
  "quote",
  "syn 2.0.106",
  "walkdir",
+]
+
+[[package]]
+name = "surrealkv"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0672cbbe282723a62ccee14b95232ca0b4c9bf44ea22fb520c43e7c517fb8ec"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc32fast",
+ "crossbeam-skiplist",
+ "fs2",
+ "getrandom 0.3.4",
+ "guardian",
+ "integer-encoding",
+ "log",
+ "lz4_flex",
+ "parking_lot",
+ "quick_cache",
+ "rand 0.9.4",
+ "scopeguard",
+ "sha2",
+ "snap",
+ "tokio",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -4955,6 +5154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5072,6 +5277,12 @@ name = "vart"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1982d899e57d646498709735f16e9224cf1e8680676ad687f930cf8b5b555ae"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -5893,6 +6104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6001,3 +6218,13 @@ name = "zmij"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/README.md
+++ b/README.md
@@ -99,7 +99,26 @@ surrealkit --host http://localhost:8000 --ns my_ns --db my_db --user root --pass
 | `--db`         | Database name                                                          | `test`                  |
 | `--user`       | Database user                                                          | `root`                  |
 | `--pass`       | Database password                                                      | `root`                  |
-| `--auth-level` | Authentication level: `root`, `namespace` / `ns`, or `database` / `db` | `root`                  |
+| `--auth-level` | Authentication level: `root`, `namespace` / `ns`, `database` / `db`, or `none` | `root`                  |
+
+### Embedded databases
+
+SurrealKit can manage an in-process SurrealDB by pointing `--host` at an embedded endpoint. Authentication is skipped automatically (a fresh embedded datastore has no users):
+
+```bash
+surrealkit --host surrealkv://./data --ns my_ns --db my_db sync
+surrealkit --host surrealkv://./data --ns my_ns --db my_db seed
+```
+
+Embedded schemes: `surrealkv://`, `rocksdb://`, `speedb://`, `mem://`, `file://`, `tikv://`. Pass `--auth-level none` to force the no-signin path on any endpoint.
+
+The **prebuilt CLI bundles only the in-memory engine** to stay light. For a CLI that can open on-disk engines, build with the matching feature:
+
+```bash
+cargo install surrealkit --features kv-surrealkv   # or kv-rocksdb, or `embedded` for all
+```
+
+Embedded engines are single-process, so run the CLI while your application is stopped (it holds an exclusive lock on the datastore). For schema management inside your application at startup, use the [library](crates/surrealkit/README.md) instead, which needs no engine feature on SurrealKit itself.
 
 ### Environment Variables
 
@@ -108,7 +127,7 @@ surrealkit --host http://localhost:8000 --ns my_ns --db my_db --user root --pass
 - `SURREALDB_NAMESPACE` (fallback: `DATABASE_NAMESPACE`)
 - `SURREALDB_USER` (fallback: `DATABASE_USER`)
 - `SURREALDB_PASSWORD` (fallback: `DATABASE_PASSWORD`)
-- `SURREALDB_AUTH_LEVEL` (fallback: `DATABASE_AUTH_LEVEL`) — accepted values: `root`, `namespace` / `ns`, `database` / `db`
+- `SURREALDB_AUTH_LEVEL` (fallback: `DATABASE_AUTH_LEVEL`), accepted values: `root`, `namespace` / `ns`, `database` / `db`, `none`
 - `SURREALDB_FOLDER` — root folder for schema, rollouts, snapshots, seed, and tests (default: `./database`)
 
 These can be set as system environment variables or in a `.env` file.
@@ -314,11 +333,14 @@ Repair never re-executes per-step SQL — it only reconciles `__rollout` and
 
 ### Seeding
 
-Seeding runs on demand:
+Seeding runs on demand and is **idempotent**. Each file is tracked in the `__seed` table by a content hash and runs only on first boot or when its content changes, so it is safe to run repeatedly (and on every deploy):
 
 ```sh
-surrealkit seed
+surrealkit seed           # applies new/changed seed files; skips unchanged ones
+surrealkit seed --force   # re-run every seed file, ignoring the tracking table
 ```
+
+To ship seeds inside a binary (no filesystem at runtime), use the library's `embed_seed!` macro. See the [library README](crates/surrealkit/README.md#embedded-seeds-embed_seed--seed).
 
 ## Template Variables
 

--- a/crates/surrealkit-macros/README.md
+++ b/crates/surrealkit-macros/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://docs.rs/surrealkit-macros/badge.svg)](https://docs.rs/surrealkit-macros)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
-Proc-macros for [SurrealKit](https://github.com/surrealdb/surrealkit). Embeds `.surql` schema files into your binary at compile time.
+Proc-macros for [SurrealKit](https://github.com/surrealdb/surrealkit). Embeds `.surql` schema and seed files into your binary at compile time.
 
 ---
 
@@ -48,6 +48,24 @@ surrealkit::embed_schema!("my/schema/dir");
 ```
 
 The generated module is always named `embedded_schema` regardless of the path.
+
+---
+
+## `embed_seed!`
+
+`embed_seed!` is the seed-file counterpart of `embed_schema!`. It bakes `.surql` seed files into the binary and generates an `embedded_seed::seed(db)` function. Seeding is tracked in the `__seed` table, so each file runs only on first boot or when its content changes.
+
+```rust
+// Reads database/seed/**/*.surql relative to your Cargo.toml.
+surrealkit::embed_seed!();
+surrealkit::embed_seed!("my/seed/dir"); // custom path
+
+# async fn run(db: &surrealkit::Surreal<surrealkit::engine::any::Any>) -> anyhow::Result<()> {
+embedded_seed::seed(db).await?;
+# Ok(()) }
+```
+
+The generated module is always named `embedded_seed` and exposes a `SEEDS: &[surrealkit::EmbeddedSeedFile]` static plus an async `seed(db)` function.
 
 ---
 

--- a/crates/surrealkit-macros/src/lib.rs
+++ b/crates/surrealkit-macros/src/lib.rs
@@ -3,8 +3,57 @@ use std::path::PathBuf;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{LitStr, parse_macro_input};
+use syn::LitStr;
 use walkdir::WalkDir;
+
+/// Resolve a macro argument to a directory relative to the caller's `Cargo.toml`,
+/// returning `(rel_dir, abs_dir)`. `default` is used when the macro is invoked
+/// with no argument.
+fn resolve_dir(input: TokenStream, default: &str, macro_name: &str) -> (String, PathBuf) {
+	let rel_dir = if input.is_empty() {
+		default.to_string()
+	} else {
+		match syn::parse::<LitStr>(input) {
+			Ok(lit) => lit.value(),
+			Err(e) => panic!("{macro_name}: expected a string literal directory path: {e}"),
+		}
+	};
+
+	let manifest_dir =
+		env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set during macro expansion");
+	let abs_dir = PathBuf::from(&manifest_dir).join(&rel_dir);
+
+	if !abs_dir.exists() {
+		panic!("{macro_name}: directory does not exist: {}", abs_dir.display());
+	}
+
+	(rel_dir, abs_dir)
+}
+
+/// Collect, sorted, the `(rel_display, abs_str)` of every `.surql` file under
+/// `abs_dir`. `rel_display` is the stable tracking key (`<rel_dir>/<relpath>`).
+fn collect_surql(rel_dir: &str, abs_dir: &PathBuf) -> Vec<(String, String)> {
+	let mut file_paths: Vec<PathBuf> = WalkDir::new(abs_dir)
+		.follow_links(true)
+		.into_iter()
+		.filter_map(|e| e.ok())
+		.filter(|e| e.file_type().is_file())
+		.map(|e| e.into_path())
+		.filter(|p| p.extension().and_then(|s| s.to_str()) == Some("surql"))
+		.collect();
+	file_paths.sort();
+
+	file_paths
+		.iter()
+		.map(|abs_path| {
+			let abs_str = abs_path.to_str().expect("non-UTF8 path in surql dir").to_string();
+			let rel = abs_path.strip_prefix(abs_dir).expect("path not under surql dir");
+			let rel_str = rel.to_str().expect("non-UTF8 relative path in surql dir");
+			let rel_display = format!("{rel_dir}/{rel_str}").replace('\\', "/");
+			(rel_display, abs_str)
+		})
+		.collect()
+}
 
 /// Embeds `.surql` schema files at compile time.
 ///
@@ -21,39 +70,11 @@ use walkdir::WalkDir;
 /// ```
 #[proc_macro]
 pub fn embed_schema(input: TokenStream) -> TokenStream {
-	let schema_dir = if input.is_empty() {
-		"database/schema".to_string()
-	} else {
-		let lit = parse_macro_input!(input as LitStr);
-		lit.value()
-	};
+	let (rel_dir, abs_dir) = resolve_dir(input, "database/schema", "embed_schema!");
 
-	let manifest_dir =
-		env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set during macro expansion");
-	let abs_schema_dir = PathBuf::from(&manifest_dir).join(&schema_dir);
-
-	if !abs_schema_dir.exists() {
-		panic!("embed_schema!: schema directory does not exist: {}", abs_schema_dir.display());
-	}
-
-	let mut file_paths: Vec<PathBuf> = WalkDir::new(&abs_schema_dir)
-		.follow_links(true)
+	let file_entries: Vec<_> = collect_surql(&rel_dir, &abs_dir)
 		.into_iter()
-		.filter_map(|e| e.ok())
-		.filter(|e| e.file_type().is_file())
-		.map(|e| e.into_path())
-		.filter(|p| p.extension().and_then(|s| s.to_str()) == Some("surql"))
-		.collect();
-	file_paths.sort();
-
-	let file_entries: Vec<_> = file_paths
-		.iter()
-		.map(|abs_path| {
-			let abs_str = abs_path.to_str().expect("non-UTF8 path in schema dir");
-			let rel = abs_path.strip_prefix(&abs_schema_dir).expect("path not under schema dir");
-			let rel_display =
-				format!("{}/{}", schema_dir, rel.to_str().unwrap()).replace('\\', "/");
-
+		.map(|(rel_display, abs_str)| {
 			quote! {
 				::surrealkit::EmbeddedSchemaFile {
 					path: #rel_display,
@@ -73,6 +94,53 @@ pub fn embed_schema(input: TokenStream) -> TokenStream {
 				db: &::surrealkit::Surreal<::surrealkit::engine::any::Any>,
 			) -> ::surrealkit::anyhow::Result<()> {
 				::surrealkit::Sync::embedded(SCHEMA).run(db).await
+			}
+		}
+	};
+
+	expanded.into()
+}
+
+/// Embeds `.surql` seed files at compile time.
+///
+/// Generates a `pub mod embedded_seed` with a `SEEDS` static and an async
+/// `seed(db)` function. Seeding is tracked in the `__seed` table, so each file
+/// runs only on first boot or when its content changes.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// surrealkit::embed_seed!();
+/// surrealkit::embed_seed!("database/seed");
+///
+/// embedded_seed::seed(&db).await?;
+/// ```
+#[proc_macro]
+pub fn embed_seed(input: TokenStream) -> TokenStream {
+	let (rel_dir, abs_dir) = resolve_dir(input, "database/seed", "embed_seed!");
+
+	let file_entries: Vec<_> = collect_surql(&rel_dir, &abs_dir)
+		.into_iter()
+		.map(|(rel_display, abs_str)| {
+			quote! {
+				::surrealkit::EmbeddedSeedFile {
+					path: #rel_display,
+					sql: include_str!(#abs_str),
+				}
+			}
+		})
+		.collect();
+
+	let expanded = quote! {
+		pub mod embedded_seed {
+			pub static SEEDS: &[::surrealkit::EmbeddedSeedFile] = &[
+				#(#file_entries),*
+			];
+
+			pub async fn seed(
+				db: &::surrealkit::Surreal<::surrealkit::engine::any::Any>,
+			) -> ::surrealkit::anyhow::Result<()> {
+				::surrealkit::Seed::embedded(SEEDS).run(db).await
 			}
 		}
 	};

--- a/crates/surrealkit/Cargo.toml
+++ b/crates/surrealkit/Cargo.toml
@@ -29,8 +29,24 @@ rustls = { version = '0.23', default-features = false, features = ['aws-lc-rs'] 
 inquire = '0.7'
 tempfile = '3'
 
+[features]
+# The published CLI binary bundles only the in-memory engine, keeping the
+# prebuilt artifact light. Remote connections (protocol-http/jwks) are always
+# available. Build the CLI with --features kv-surrealkv (or `embedded`) for an
+# embedded build.
+#
+# Library consumers do NOT need these features to target an embedded engine:
+# Cargo unifies features across the dependency graph, so enabling e.g.
+# `surrealdb/kv-surrealkv` in your own crate is enough for SurrealKit's
+# `Surreal<Any>` to open `surrealkv://`.
+default = ['kv-mem']
+kv-mem = ['surrealdb/kv-mem']
+kv-surrealkv = ['surrealdb/kv-surrealkv']
+kv-rocksdb = ['surrealdb/kv-rocksdb']
+# Convenience: a full embedded CLI with every supported local engine.
+embedded = ['kv-surrealkv', 'kv-rocksdb', 'kv-mem']
+
 [dev-dependencies]
-surrealdb = { version = '3.1.4', features = ['kv-mem'] }
 test-case = '3'
 
 [lints]

--- a/crates/surrealkit/README.md
+++ b/crates/surrealkit/README.md
@@ -46,7 +46,31 @@ let db = connect(&cfg).await?;
 # Ok(()) }
 ```
 
-For an in-process SurrealDB (e.g. `mem://`, `rocksdb://`), construct a `Surreal` directly and pass it to any library function:
+### Embedded databases
+
+SurrealKit works against an in-process SurrealDB such as `mem://`, `surrealkv://`, or `rocksdb://`. Because Cargo unifies features across the dependency graph, you only need to enable the engine on **your own** `surrealdb` dependency. SurrealKit itself stays engine-agnostic:
+
+```toml
+[dependencies]
+surrealkit = "0.7"
+surrealdb = { version = "3", features = ["kv-surrealkv"] }
+```
+
+`connect` detects embedded endpoints and skips authentication automatically (a fresh embedded datastore has no users), so the same `DbCfg`/`connect` flow works:
+
+```rust,no_run
+use surrealkit::{DbCfg, DbOverrides, connect};
+
+# async fn run() -> anyhow::Result<()> {
+let cfg = DbCfg::from_env(None, &DbOverrides {
+    host: Some("surrealkv://./data".into()),
+    ..Default::default()
+})?;
+let db = connect(&cfg).await?; // no signin; goes straight to use_ns/use_db
+# Ok(()) }
+```
+
+Or construct a `Surreal` directly and pass it to any library function:
 
 ```rust,no_run
 use surrealdb::engine::any::connect;
@@ -58,6 +82,8 @@ let db = connect(("mem://", Config::new().capabilities(Capabilities::all()))).aw
 db.use_ns("my_ns").use_db("my_db").await?;
 # Ok(()) }
 ```
+
+Endpoints treated as embedded (no signin): `mem://`, `surrealkv://`, `rocksdb://`, `speedb://`, `file://`, `tikv://`, `indxdb://`. Pass `--auth-level none` (CLI) to force this for any endpoint.
 
 ---
 
@@ -214,6 +240,8 @@ Rollout::abandon(db, "20260604__add_account").await?;
 
 ## Seeding
 
+Seeding is **idempotent**: each file is tracked in the `__seed` table by a content hash, so it runs only on first boot or when its `sql` changes. This makes it safe to call on every startup, so re-running a seed of fixed-id records no longer errors.
+
 [`seed`] runs `.surql` files from a `seed/` directory (lexicographic order), applying template variables:
 
 ```rust,no_run
@@ -223,6 +251,39 @@ Rollout::abandon(db, "20260604__add_account").await?;
 seed(db, "database", &TemplateVars::default()).await?;
 # Ok(()) }
 ```
+
+### Embedded seeds (`embed_seed!` / `Seed`)
+
+To ship seeds inside a production binary, with no filesystem at runtime, bake them in with `embed_seed!` (the counterpart to `embed_schema!`):
+
+```rust,ignore
+// Reads database/seed/**/*.surql relative to your Cargo.toml at compile time.
+surrealkit::embed_seed!();
+
+# async fn run(db: &surrealkit::Surreal<surrealkit::engine::any::Any>) -> anyhow::Result<()> {
+embedded_seed::seed(db).await?; // runs each file once; tracked in __seed
+# Ok(()) }
+```
+
+For runtime control, use the [`Seed`] builder directly:
+
+```rust,no_run
+use surrealkit::{EmbeddedSeedFile, Seed, Surreal};
+use surrealkit::engine::any::Any;
+
+static SEEDS: &[EmbeddedSeedFile] = &[EmbeddedSeedFile {
+    path: "database/seed/countries.surql",
+    sql:  "INSERT INTO country [ { id: 'us', name: 'United States' } ];",
+}];
+
+# async fn run(db: &Surreal<Any>) -> anyhow::Result<()> {
+Seed::embedded(SEEDS).run(db).await?;            // first boot only
+Seed::embedded(SEEDS).force(true).run(db).await?; // re-run everything
+Seed::from_dir("database").run(db).await?;        // or seed from disk
+# Ok(()) }
+```
+
+Like [`EmbeddedSchemaFile`], `EmbeddedSeedFile::path` is a **stable tracking key** (not a path that must exist on disk) and `sql` is the content. Changing `sql` while holding `path` constant re-runs the file.
 
 ---
 
@@ -234,9 +295,10 @@ seed(db, "database", &TemplateVars::default()).await?;
 
 ## Metadata tables
 
-SurrealKit maintains two internal tables in your namespace/database, created automatically:
+SurrealKit maintains these internal tables in your namespace/database, created automatically:
 
 | Table | Purpose |
 |---|---|
 | `__entity` | Tracks every schema object SurrealKit manages (content hash, tracking key) |
 | `__rollout` | Tracks rollout execution state (see the status lifecycle above) |
+| `__seed` | Tracks applied seed files by content hash so they run only once / on change |

--- a/crates/surrealkit/src/config.rs
+++ b/crates/surrealkit/src/config.rs
@@ -19,6 +19,13 @@ pub enum AuthLevel {
 	Namespace,
 	/// Sign in as a database-scoped user. Credentials must exist on the target database.
 	Database,
+	/// Skip authentication entirely and go straight to `use_ns`/`use_db`.
+	///
+	/// This is the right choice for embedded engines such as `surrealkv://`,
+	/// `rocksdb://`, and `mem://`, which have no users defined on a fresh datastore.
+	/// It is selected automatically when the host is an embedded endpoint; pass
+	/// `--auth-level none` to force it for any endpoint.
+	None,
 }
 
 impl AuthLevel {
@@ -27,9 +34,28 @@ impl AuthLevel {
 			"root" => Some(Self::Root),
 			"namespace" | "ns" => Some(Self::Namespace),
 			"database" | "db" => Some(Self::Database),
+			"none" | "no-auth" | "noauth" => Some(Self::None),
 			_ => None,
 		}
 	}
+}
+
+/// Returns `true` for endpoints served by an in-process embedded engine, which
+/// have no authentication on a fresh datastore. Matching is case-insensitive on
+/// the URL scheme.
+pub(crate) fn is_embedded_endpoint(host: &str) -> bool {
+	let lower = host.to_ascii_lowercase();
+	const EMBEDDED_SCHEMES: &[&str] = &[
+		"mem://",
+		"surrealkv://",
+		"surrealkv+versioned://",
+		"rocksdb://",
+		"speedb://",
+		"file://",
+		"tikv://",
+		"indxdb://",
+	];
+	EMBEDDED_SCHEMES.iter().any(|scheme| lower.starts_with(scheme))
 }
 
 #[derive(Debug, Clone, Default)]
@@ -184,6 +210,40 @@ mod tests {
 			unset_env("DATABASE_PASSWORD");
 			unset_env("DATABASE_AUTH_LEVEL");
 		}
+	}
+
+	#[test]
+	fn is_embedded_endpoint_matches_local_schemes() {
+		for host in [
+			"mem://",
+			"surrealkv://./data",
+			"SURREALKV://Data",
+			"surrealkv+versioned://./data",
+			"rocksdb://./db",
+			"speedb://./db",
+			"file://./db",
+			"tikv://127.0.0.1:2379",
+			"indxdb://mydb",
+		] {
+			assert!(is_embedded_endpoint(host), "expected embedded: {host}");
+		}
+	}
+
+	#[test]
+	fn is_embedded_endpoint_rejects_remote_schemes() {
+		for host in
+			["http://localhost:8000", "https://db.example.com", "ws://localhost:8000", "wss://x"]
+		{
+			assert!(!is_embedded_endpoint(host), "expected remote: {host}");
+		}
+	}
+
+	#[test]
+	fn auth_level_parses_none_spellings() {
+		assert_eq!(AuthLevel::parse("none"), Some(AuthLevel::None));
+		assert_eq!(AuthLevel::parse("NONE"), Some(AuthLevel::None));
+		assert_eq!(AuthLevel::parse("no-auth"), Some(AuthLevel::None));
+		assert_eq!(AuthLevel::parse("noauth"), Some(AuthLevel::None));
 	}
 
 	// resolve() unit tests use unique key names, safe to run in parallel
@@ -374,7 +434,21 @@ pub async fn connect(cfg: &DbCfg) -> Result<Surreal<Any>> {
 		.await
 		.with_context(|| format!("Failed connecting to {}", cfg.host))?;
 
-	match cfg.auth_level {
+	// Embedded engines have no users on a fresh datastore, so signing in would
+	// fail. Auto-detect them and skip auth (unless the user forced a level).
+	let auth_level = if is_embedded_endpoint(&cfg.host) {
+		AuthLevel::None
+	} else {
+		cfg.auth_level.clone()
+	};
+
+	match auth_level {
+		AuthLevel::None => {
+			db.use_ns(&cfg.ns)
+				.use_db(&cfg.db)
+				.await
+				.with_context(|| format!("use_ns/use_db failed for ns={} db={}", cfg.ns, cfg.db))?;
+		}
 		AuthLevel::Root => {
 			db.signin(Root {
 				username: cfg.user.clone(),

--- a/crates/surrealkit/src/lib.rs
+++ b/crates/surrealkit/src/lib.rs
@@ -16,7 +16,7 @@ pub mod variables;
 // Re-exported dependencies used in the public API surface.
 pub use anyhow;
 pub use surrealdb::{self, Surreal, engine};
-pub use surrealkit_macros::embed_schema;
+pub use surrealkit_macros::{embed_schema, embed_seed};
 
 // Connecting.
 pub use config::{AuthLevel, DbCfg, DbOverrides, connect};
@@ -32,7 +32,7 @@ pub use rollout::{
 pub use schema_state::{EntityKey, EntityKind};
 
 // Seeding.
-pub use seed::seed;
+pub use seed::{EmbeddedSeedFile, Seed, seed};
 
 // Type generation (programmatic).
 pub use typegen::{SchemaTypes, TypegenOpts, generate};

--- a/crates/surrealkit/src/lib.rs
+++ b/crates/surrealkit/src/lib.rs
@@ -15,27 +15,21 @@ pub mod variables;
 
 // Re-exported dependencies used in the public API surface.
 pub use anyhow;
-pub use surrealdb::{self, Surreal, engine};
-pub use surrealkit_macros::{embed_schema, embed_seed};
-
 // Connecting.
 pub use config::{AuthLevel, DbCfg, DbOverrides, connect};
-
-// Schema sync (the simple, desired-state path).
-pub use sync::{EmbeddedSchemaFile, Sync};
-
 // Rollouts (the staged, reversible path).
 pub use rollout::{
 	Rollout, RolloutAction, RolloutCompatibility, RolloutPhase, RolloutSpec, RolloutSpecBuilder,
 	RolloutStatus, RolloutStatusReport, RolloutStep, RolloutStepStatus,
 };
 pub use schema_state::{EntityKey, EntityKind};
-
 // Seeding.
 pub use seed::{EmbeddedSeedFile, Seed, seed};
-
+pub use surrealdb::{self, Surreal, engine};
+pub use surrealkit_macros::{embed_schema, embed_seed};
+// Schema sync (the simple, desired-state path).
+pub use sync::{EmbeddedSchemaFile, Sync};
 // Type generation (programmatic).
 pub use typegen::{SchemaTypes, TypegenOpts, generate};
-
 // Template variables.
 pub use variables::TemplateVars;

--- a/crates/surrealkit/src/main.rs
+++ b/crates/surrealkit/src/main.rs
@@ -5,7 +5,6 @@ use rust_dotenv::dotenv::DotEnv;
 use surrealkit::config::{DbCfg, DbOverrides, connect};
 use surrealkit::core::exec_surql;
 use surrealkit::rollout::{self, RolloutExecutionOpts, RolloutPlanOpts};
-use surrealkit::seed;
 use surrealkit::setup::run_setup;
 use surrealkit::sync::{self, SyncOpts};
 use surrealkit::tester::{TestOpts, run_test};
@@ -108,7 +107,13 @@ enum Commands {
 		#[command(subcommand)]
 		command: RolloutCommands,
 	},
-	Seed,
+	/// Run seed files. Each file runs only on first boot or when its content
+	/// changes (tracked in the `__seed` table). Use `--force` to re-run all.
+	Seed {
+		/// Re-run every seed file, ignoring the `__seed` tracking table.
+		#[arg(long)]
+		force: bool,
+	},
 	Status,
 	Apply {
 		path: PathBuf,
@@ -366,9 +371,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 				.await?;
 			}
 		},
-		Commands::Seed => {
+		Commands::Seed {
+			force,
+		} => {
 			let db = connect(&cfg).await?;
-			seed::seed(&db, &folder, &template_vars).await?;
+			surrealkit::Seed::from_dir(folder.clone())
+				.vars(template_vars)
+				.force(force)
+				.run(&db)
+				.await?;
 		}
 		Commands::Status => {
 			let db = connect(&cfg).await?;

--- a/crates/surrealkit/src/scaffold.rs
+++ b/crates/surrealkit/src/scaffold.rs
@@ -144,6 +144,23 @@ DEFINE FIELD OVERWRITE last_error ON __rollout
 DEFINE INDEX OVERWRITE by_rollout_id ON __rollout
 	FIELDS id
 	UNIQUE;
+
+DEFINE TABLE OVERWRITE __seed SCHEMAFULL
+	PERMISSIONS NONE;
+
+DEFINE FIELD OVERWRITE key ON __seed
+	TYPE string;
+
+DEFINE FIELD OVERWRITE hash ON __seed
+	TYPE string;
+
+DEFINE FIELD OVERWRITE applied_at ON __seed
+	TYPE datetime
+	DEFAULT time::now();
+
+DEFINE INDEX OVERWRITE by_seed_key ON __seed
+	FIELDS key
+	UNIQUE;
 "#;
 
 pub const DEFAULT_TEST_CONFIG: &str = r#"[defaults]

--- a/crates/surrealkit/src/schema_state.rs
+++ b/crates/surrealkit/src/schema_state.rs
@@ -1,8 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::{fmt, fs};
 
 use anyhow::{Context, Result, anyhow, bail};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/surrealkit/src/seed.rs
+++ b/crates/surrealkit/src/seed.rs
@@ -26,11 +26,11 @@ DEFINE INDEX IF NOT EXISTS by_seed_key ON __seed FIELDS key UNIQUE;";
 /// Produced by the [`embed_seed!`](crate::embed_seed) macro, or constructed by
 /// hand for use with [`Seed::embedded`].
 ///
-/// - **`path` is a stable tracking key**, *not* a path that must exist on disk.
-///   SurrealKit records it in the `__seed` table to detect content changes and
-///   decide whether a file still needs to run. Keep it stable across releases.
-/// - **`sql` is the content** that gets executed. Changing `sql` while holding
-///   `path` constant is what triggers a re-run on the next seed.
+/// - **`path` is a stable tracking key**, *not* a path that must exist on disk. SurrealKit records
+///   it in the `__seed` table to detect content changes and decide whether a file still needs to
+///   run. Keep it stable across releases.
+/// - **`sql` is the content** that gets executed. Changing `sql` while holding `path` constant is
+///   what triggers a re-run on the next seed.
 pub struct EmbeddedSeedFile {
 	pub path: &'static str,
 	pub sql: &'static str,
@@ -265,11 +265,7 @@ async fn store_seed_hash(db: &Surreal<Any>, key: &str, hash: &str) -> Result<()>
 		 DELETE __seed WHERE key = $key; \
 		 CREATE __seed CONTENT {{ key: $key, hash: $hash, applied_at: time::now() }};",
 	);
-	db.query(sql)
-		.bind(("key", key.to_string()))
-		.bind(("hash", hash.to_string()))
-		.await?
-		.check()?;
+	db.query(sql).bind(("key", key.to_string())).bind(("hash", hash.to_string())).await?.check()?;
 	Ok(())
 }
 

--- a/crates/surrealkit/src/seed.rs
+++ b/crates/surrealkit/src/seed.rs
@@ -1,47 +1,202 @@
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
 use surrealdb::Surreal;
 use surrealdb::engine::any::Any;
 
 use crate::constants::seed_dir;
-use crate::core::{display, exec_surql};
+use crate::core::{display, exec_surql, sha256_hex};
+use crate::setup::run_setup_embedded;
 use crate::variables::TemplateVars;
 
-pub async fn seed(db: &Surreal<Any>, folder: &str, vars: &TemplateVars) -> Result<()> {
-	let seed_dir = seed_dir(folder);
-	let seed_file = crate::constants::deprecated_seed_surql_path(folder);
+/// A seed file baked into the binary at compile time.
+///
+/// Produced by the [`embed_seed!`](crate::embed_seed) macro, or constructed by
+/// hand for use with [`Seed::embedded`].
+///
+/// - **`path` is a stable tracking key**, *not* a path that must exist on disk.
+///   SurrealKit records it in the `__seed` table to detect content changes and
+///   decide whether a file still needs to run. Keep it stable across releases.
+/// - **`sql` is the content** that gets executed. Changing `sql` while holding
+///   `path` constant is what triggers a re-run on the next seed.
+pub struct EmbeddedSeedFile {
+	pub path: &'static str,
+	pub sql: &'static str,
+}
 
-	if seed_dir.is_dir() {
-		seed_from_dir(db, &seed_dir, vars).await
-	} else if seed_file.exists() {
-		eprintln!(
-			"warning: {}/seed.surql is deprecated and will be removed in v1. \
-			Move your seed files into {}/seed/ instead.",
-			folder, folder
-		);
-		let sql = fs::read_to_string(&seed_file)
-			.with_context(|| format!("reading {}", display(&seed_file)))?;
-		let sql = vars.apply(&sql)?;
-		exec_surql(db, &sql).await
-	} else {
-		Err(anyhow!("no seed found: create {}/seed.surql or a {}/seed/ directory", folder, folder))
+enum SeedSource<'a> {
+	Embedded(&'a [EmbeddedSeedFile]),
+	Dir(String),
+}
+
+/// Runs seed `.surql` files, tracking each one in the `__seed` table so it only
+/// executes on first boot or when its content hash changes.
+///
+/// ```rust,no_run
+/// # use surrealkit::{Seed, EmbeddedSeedFile, Surreal};
+/// # use surrealkit::engine::any::Any;
+/// static SEEDS: &[EmbeddedSeedFile] = &[EmbeddedSeedFile {
+///     path: "database/seed/countries.surql",
+///     sql:  "INSERT INTO country [ { id: 'us', name: 'United States' } ];",
+/// }];
+/// # async fn run(db: &Surreal<Any>) -> anyhow::Result<()> {
+/// Seed::embedded(SEEDS).run(db).await?;        // runs once; no-op on next boot
+/// Seed::embedded(SEEDS).force(true).run(db).await?; // re-run everything
+/// # Ok(()) }
+/// ```
+pub struct Seed<'a> {
+	source: SeedSource<'a>,
+	vars: TemplateVars,
+	force: bool,
+}
+
+impl<'a> Seed<'a> {
+	/// Seed from files embedded in the binary (see [`EmbeddedSeedFile`]).
+	pub fn embedded(files: &'a [EmbeddedSeedFile]) -> Self {
+		Self {
+			source: SeedSource::Embedded(files),
+			vars: TemplateVars::default(),
+			force: false,
+		}
 	}
+
+	/// Seed from a project folder on disk. Resolves `<folder>/seed/` (preferred)
+	/// or the deprecated `<folder>/seed.surql` single file.
+	pub fn from_dir(folder: impl Into<String>) -> Self {
+		Self {
+			source: SeedSource::Dir(folder.into()),
+			vars: TemplateVars::default(),
+			force: false,
+		}
+	}
+
+	/// Template variables applied to each file before execution.
+	pub fn vars(mut self, vars: TemplateVars) -> Self {
+		self.vars = vars;
+		self
+	}
+
+	/// Re-run every file regardless of its tracked hash.
+	pub fn force(mut self, force: bool) -> Self {
+		self.force = force;
+		self
+	}
+
+	pub async fn run(self, db: &Surreal<Any>) -> Result<()> {
+		let Seed {
+			source,
+			vars,
+			force,
+		} = self;
+		match source {
+			SeedSource::Embedded(files) => {
+				run_setup_embedded(db).await?;
+				let tracked = load_seed_hashes(db).await?;
+				let mut stats = SeedStats::default();
+				for f in files {
+					apply_seed(db, f.path, f.sql, &tracked, force, &vars, &mut stats).await?;
+				}
+				stats.report();
+				Ok(())
+			}
+			SeedSource::Dir(folder) => {
+				let dir = seed_dir(&folder);
+				#[expect(deprecated)]
+				let deprecated = crate::constants::deprecated_seed_surql_path(&folder);
+
+				if dir.is_dir() {
+					run_dir(db, &dir, &vars, force).await
+				} else if deprecated.exists() {
+					eprintln!(
+						"warning: {}/seed.surql is deprecated and will be removed in v1. \
+						Move your seed files into {}/seed/ instead.",
+						folder, folder
+					);
+					run_setup_embedded(db).await?;
+					let tracked = load_seed_hashes(db).await?;
+					let mut stats = SeedStats::default();
+					let raw = fs::read_to_string(&deprecated)
+						.with_context(|| format!("reading {}", display(&deprecated)))?;
+					let key = display(&deprecated);
+					apply_seed(db, &key, &raw, &tracked, force, &vars, &mut stats).await?;
+					stats.report();
+					Ok(())
+				} else {
+					Err(anyhow!(
+						"no seed found: create {}/seed.surql or a {}/seed/ directory",
+						folder,
+						folder
+					))
+				}
+			}
+		}
+	}
+}
+
+/// Seed a project `folder` from disk. Equivalent to
+/// `Seed::from_dir(folder).vars(vars.clone()).run(db)`.
+///
+/// Seeding is idempotent: each file runs only on first boot or when its content
+/// changes. Use [`Seed::force`] (or the CLI `--force` flag) to re-run everything.
+pub async fn seed(db: &Surreal<Any>, folder: &str, vars: &TemplateVars) -> Result<()> {
+	Seed::from_dir(folder).vars(vars.clone()).run(db).await
 }
 
 #[doc(hidden)]
 pub async fn seed_from_dir(db: &Surreal<Any>, dir: &Path, vars: &TemplateVars) -> Result<()> {
-	let mut files: Vec<_> = fs::read_dir(dir)
+	run_dir(db, dir, vars, false).await
+}
+
+/// Counters for a single seed run.
+#[derive(Default)]
+struct SeedStats {
+	executed: usize,
+	skipped: usize,
+}
+
+impl SeedStats {
+	fn report(&self) {
+		println!("Seeded {} file(s); {} unchanged", self.executed, self.skipped);
+	}
+}
+
+/// Hash, decide, and (if needed) execute a single seed file, recording its hash.
+async fn apply_seed(
+	db: &Surreal<Any>,
+	key: &str,
+	raw_sql: &str,
+	tracked: &BTreeMap<String, String>,
+	force: bool,
+	vars: &TemplateVars,
+	stats: &mut SeedStats,
+) -> Result<()> {
+	let hash = sha256_hex(raw_sql.as_bytes());
+
+	if !force && tracked.get(key).is_some_and(|prev| prev == &hash) {
+		println!("  skipping {key} (unchanged)");
+		stats.skipped += 1;
+		return Ok(());
+	}
+
+	println!("  executing {key}");
+	let sql =
+		vars.apply(raw_sql).with_context(|| format!("applying template variables in {key}"))?;
+	exec_surql(db, &sql).await.with_context(|| format!("executing {key}"))?;
+	store_seed_hash(db, key, &hash).await?;
+	stats.executed += 1;
+	Ok(())
+}
+
+/// Run all `.surql` files directly inside `dir` (single level, lexicographic),
+/// with `__seed` hash tracking.
+async fn run_dir(db: &Surreal<Any>, dir: &Path, vars: &TemplateVars, force: bool) -> Result<()> {
+	let mut files: Vec<PathBuf> = fs::read_dir(dir)
 		.with_context(|| format!("reading directory {}", display(dir)))?
 		.filter_map(|entry| {
-			let entry = entry.ok()?;
-			let path = entry.path();
-			if path.extension().and_then(|e| e.to_str()) == Some("surql") {
-				Some(path)
-			} else {
-				None
-			}
+			let path = entry.ok()?.path();
+			(path.extension().and_then(|e| e.to_str()) == Some("surql")).then_some(path)
 		})
 		.collect();
 
@@ -53,17 +208,46 @@ pub async fn seed_from_dir(db: &Surreal<Any>, dir: &Path, vars: &TemplateVars) -
 
 	println!("Seeding from {} ({} files found)", display(dir), files.len());
 
+	run_setup_embedded(db).await?;
+	let tracked = load_seed_hashes(db).await?;
+	let mut stats = SeedStats::default();
+
 	for path in &files {
-		println!("  executing {}", display(path));
-		let sql = fs::read_to_string(path).with_context(|| format!("reading {}", display(path)))?;
-		let sql = vars
-			.apply(&sql)
-			.with_context(|| format!("applying template variables in {}", display(path)))?;
-		exec_surql(db, &sql).await.with_context(|| format!("executing {}", display(path)))?;
+		let raw = fs::read_to_string(path).with_context(|| format!("reading {}", display(path)))?;
+		let key = display(path);
+		apply_seed(db, &key, &raw, &tracked, force, vars, &mut stats).await?;
 	}
 
-	println!("Seeded {} files", files.len());
+	stats.report();
+	Ok(())
+}
 
+/// Load all tracked seed hashes (`key` to `hash`) from the `__seed` table.
+async fn load_seed_hashes(db: &Surreal<Any>) -> Result<BTreeMap<String, String>> {
+	let mut resp = db.query("SELECT key, hash FROM __seed;").await?;
+	let rows: Vec<serde_json::Value> = resp.take(0)?;
+
+	let mut out = BTreeMap::new();
+	for row in rows {
+		let key = row.get("key").and_then(|v| v.as_str()).map(str::to_string);
+		let hash = row.get("hash").and_then(|v| v.as_str()).map(str::to_string);
+		if let (Some(key), Some(hash)) = (key, hash) {
+			out.insert(key, hash);
+		}
+	}
+	Ok(out)
+}
+
+/// Record (or overwrite) the hash for a seed `key` in the `__seed` table.
+async fn store_seed_hash(db: &Surreal<Any>, key: &str, hash: &str) -> Result<()> {
+	db.query(
+		"DELETE __seed WHERE key = $key; \
+		 CREATE __seed CONTENT { key: $key, hash: $hash, applied_at: time::now() };",
+	)
+	.bind(("key", key.to_string()))
+	.bind(("hash", hash.to_string()))
+	.await?
+	.check()?;
 	Ok(())
 }
 
@@ -175,5 +359,80 @@ mod tests {
 			db.query("SELECT count() FROM chunk_0 GROUP ALL").await.unwrap().take(0).unwrap();
 		let n = count.and_then(|v| v["count"].as_u64()).unwrap_or(0);
 		assert_eq!(n, records_per_file as u64);
+	}
+
+	async fn seed_count(db: &Surreal<Any>) -> u64 {
+		count_rows(db, "__seed").await
+	}
+
+	/// Number of rows in a table (0 when it doesn't exist).
+	async fn count_rows(db: &Surreal<Any>, table: &str) -> u64 {
+		let q = format!("SELECT count() FROM {table} GROUP ALL");
+		let count: Option<serde_json::Value> = db.query(q).await.unwrap().take(0).unwrap();
+		count.and_then(|v| v["count"].as_u64()).unwrap_or(0)
+	}
+
+	#[tokio::test]
+	async fn embedded_seed_runs_once_then_skips_unchanged() {
+		// Each execution appends a row; counting `marker` rows counts executions.
+		static SEEDS: &[EmbeddedSeedFile] = &[EmbeddedSeedFile {
+			path: "database/seed/people.surql",
+			sql: "CREATE marker SET at = time::now();",
+		}];
+
+		let db = mem_db().await;
+		Seed::embedded(SEEDS).run(&db).await.unwrap();
+		// A second run with the same content must be a no-op.
+		Seed::embedded(SEEDS).run(&db).await.unwrap();
+
+		assert_eq!(count_rows(&db, "marker").await, 1, "unchanged seed should run exactly once");
+		assert_eq!(seed_count(&db).await, 1, "one __seed row tracked");
+	}
+
+	#[tokio::test]
+	async fn embedded_seed_reruns_when_content_changes() {
+		let db = mem_db().await;
+
+		static V1: &[EmbeddedSeedFile] = &[EmbeddedSeedFile {
+			path: "database/seed/people.surql",
+			sql: "CREATE marker SET at = time::now();",
+		}];
+		// Same tracking key, different content, so it must re-run.
+		static V2: &[EmbeddedSeedFile] = &[EmbeddedSeedFile {
+			path: "database/seed/people.surql",
+			sql: "CREATE marker SET at = time::now(); -- v2",
+		}];
+
+		Seed::embedded(V1).run(&db).await.unwrap();
+		Seed::embedded(V2).run(&db).await.unwrap();
+
+		assert_eq!(count_rows(&db, "marker").await, 2, "changed content should re-run");
+	}
+
+	#[tokio::test]
+	async fn force_reruns_unchanged_seed() {
+		static SEEDS: &[EmbeddedSeedFile] = &[EmbeddedSeedFile {
+			path: "database/seed/people.surql",
+			sql: "CREATE marker SET at = time::now();",
+		}];
+
+		let db = mem_db().await;
+		Seed::embedded(SEEDS).run(&db).await.unwrap();
+		Seed::embedded(SEEDS).force(true).run(&db).await.unwrap();
+
+		assert_eq!(count_rows(&db, "marker").await, 2, "force should re-run even when unchanged");
+	}
+
+	#[tokio::test]
+	async fn dir_seed_is_idempotent_across_runs() {
+		let tmp = TempDir::new().unwrap();
+		fs::write(tmp.path().join("01.surql"), "CREATE once:1 SET n = 1;").unwrap();
+
+		let db = mem_db().await;
+		seed_from_dir(&db, tmp.path(), &TemplateVars::default()).await.unwrap();
+		// Re-running would error (`CREATE` on an existing id) if it weren't tracked.
+		seed_from_dir(&db, tmp.path(), &TemplateVars::default()).await.unwrap();
+
+		assert_eq!(seed_count(&db).await, 1, "one tracked seed file");
 	}
 }

--- a/crates/surrealkit/src/seed.rs
+++ b/crates/surrealkit/src/seed.rs
@@ -8,8 +8,18 @@ use surrealdb::engine::any::Any;
 
 use crate::constants::seed_dir;
 use crate::core::{display, exec_surql, sha256_hex};
-use crate::setup::run_setup_embedded;
 use crate::variables::TemplateVars;
+
+/// Lazily provisions the `__seed` tracking table. Run as part of the first write
+/// in a seed run, so seeding stays decoupled from `setup` and works on instances
+/// provisioned before this table existed. `IF NOT EXISTS` keeps it idempotent
+/// and a no-op once the table is present (e.g. created by `surrealkit setup`).
+const ENSURE_SEED_TABLE: &str = "\
+DEFINE TABLE IF NOT EXISTS __seed SCHEMAFULL PERMISSIONS NONE; \
+DEFINE FIELD IF NOT EXISTS key ON __seed TYPE string; \
+DEFINE FIELD IF NOT EXISTS hash ON __seed TYPE string; \
+DEFINE FIELD IF NOT EXISTS applied_at ON __seed TYPE datetime DEFAULT time::now(); \
+DEFINE INDEX IF NOT EXISTS by_seed_key ON __seed FIELDS key UNIQUE;";
 
 /// A seed file baked into the binary at compile time.
 ///
@@ -92,7 +102,6 @@ impl<'a> Seed<'a> {
 		} = self;
 		match source {
 			SeedSource::Embedded(files) => {
-				run_setup_embedded(db).await?;
 				let tracked = load_seed_hashes(db).await?;
 				let mut stats = SeedStats::default();
 				for f in files {
@@ -114,7 +123,6 @@ impl<'a> Seed<'a> {
 						Move your seed files into {}/seed/ instead.",
 						folder, folder
 					);
-					run_setup_embedded(db).await?;
 					let tracked = load_seed_hashes(db).await?;
 					let mut stats = SeedStats::default();
 					let raw = fs::read_to_string(&deprecated)
@@ -208,7 +216,6 @@ async fn run_dir(db: &Surreal<Any>, dir: &Path, vars: &TemplateVars, force: bool
 
 	println!("Seeding from {} ({} files found)", display(dir), files.len());
 
-	run_setup_embedded(db).await?;
 	let tracked = load_seed_hashes(db).await?;
 	let mut stats = SeedStats::default();
 
@@ -223,9 +230,17 @@ async fn run_dir(db: &Surreal<Any>, dir: &Path, vars: &TemplateVars, force: bool
 }
 
 /// Load all tracked seed hashes (`key` to `hash`) from the `__seed` table.
+///
+/// The table is created lazily on first write (see [`store_seed_hash`]), so it
+/// may not exist yet on a fresh datastore or an instance provisioned before it
+/// was introduced. A read against a missing table yields no tracked hashes,
+/// which simply means every seed is treated as new — so we never define schema
+/// here and tolerate the table's absence.
 async fn load_seed_hashes(db: &Surreal<Any>) -> Result<BTreeMap<String, String>> {
-	let mut resp = db.query("SELECT key, hash FROM __seed;").await?;
-	let rows: Vec<serde_json::Value> = resp.take(0)?;
+	let rows: Vec<serde_json::Value> = match db.query("SELECT key, hash FROM __seed;").await {
+		Ok(mut resp) => resp.take(0).unwrap_or_default(),
+		Err(_) => Vec::new(),
+	};
 
 	let mut out = BTreeMap::new();
 	for row in rows {
@@ -238,16 +253,23 @@ async fn load_seed_hashes(db: &Surreal<Any>) -> Result<BTreeMap<String, String>>
 	Ok(out)
 }
 
-/// Record (or overwrite) the hash for a seed `key` in the `__seed` table.
+/// Record (or overwrite) the hash for a seed `key` in the `__seed` table,
+/// provisioning the table first if it doesn't exist yet (see [`ENSURE_SEED_TABLE`]).
+///
+/// This is the only place that defines schema, and it runs only when a seed
+/// actually executes — so a run where every file is unchanged performs no DDL
+/// and needs no `DEFINE` privileges.
 async fn store_seed_hash(db: &Surreal<Any>, key: &str, hash: &str) -> Result<()> {
-	db.query(
-		"DELETE __seed WHERE key = $key; \
-		 CREATE __seed CONTENT { key: $key, hash: $hash, applied_at: time::now() };",
-	)
-	.bind(("key", key.to_string()))
-	.bind(("hash", hash.to_string()))
-	.await?
-	.check()?;
+	let sql = format!(
+		"{ENSURE_SEED_TABLE} \
+		 DELETE __seed WHERE key = $key; \
+		 CREATE __seed CONTENT {{ key: $key, hash: $hash, applied_at: time::now() }};",
+	);
+	db.query(sql)
+		.bind(("key", key.to_string()))
+		.bind(("hash", hash.to_string()))
+		.await?
+		.check()?;
 	Ok(())
 }
 

--- a/crates/surrealkit/src/templates/emit.rs
+++ b/crates/surrealkit/src/templates/emit.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
+use surrealkit::constants::{fixtures_dir, schema_dir, seed_dir, suites_dir};
 
 use super::manifest::{Feature, TemplateManifest};
 use super::source::TemplateFiles;
-use surrealkit::constants::{fixtures_dir, schema_dir, seed_dir, suites_dir};
 
 /// One file to write, with its resolved content already loaded from the source.
 #[derive(Debug, Clone)]

--- a/crates/surrealkit/src/templates/mod.rs
+++ b/crates/surrealkit/src/templates/mod.rs
@@ -11,13 +11,11 @@ mod manifest;
 mod select;
 mod source;
 
-pub use select::InitOpts;
-
 use anyhow::Result;
-use surrealkit::scaffold;
-
 use emit::EmitPlan;
+pub use select::InitOpts;
 use source::TemplateSource;
+use surrealkit::scaffold;
 
 /// Run `surrealkit init`: scaffold the base project and layer on the selected
 /// template features.

--- a/crates/surrealkit/src/tester/actors.rs
+++ b/crates/surrealkit/src/tester/actors.rs
@@ -108,8 +108,10 @@ async fn build_default_bootstrap_session(
 				.await
 				.with_context(|| format!("switching bootstrap actor to db={database}"))?;
 		}
-		AuthLevel::Database => {
-			unreachable!("AuthLevel::Database is rejected by tester::run_test before reaching here")
+		AuthLevel::Database | AuthLevel::None => {
+			unreachable!(
+				"AuthLevel::Database/None are rejected by tester::run_test before reaching here"
+			)
 		}
 	}
 

--- a/crates/surrealkit/src/tester/mod.rs
+++ b/crates/surrealkit/src/tester/mod.rs
@@ -29,6 +29,17 @@ pub async fn run_test(
 			 Database-scoped users cannot create the per-suite database needed for test isolation."
 		);
 	}
+	// Embedded endpoints resolve to `AuthLevel::None` (no signin). The test
+	// harness signs in per actor and creates an isolated namespace/database per
+	// suite, which the no-auth path does not yet support.
+	if matches!(cfg.auth_level(), AuthLevel::None)
+		|| crate::config::is_embedded_endpoint(cfg.host())
+	{
+		bail!(
+			"`surrealkit test` does not yet support embedded engines or auth level 'none'; \
+			 use a server endpoint with auth level 'root' or 'namespace'/'ns'."
+		);
+	}
 	let loaded = loader::load_specs(cfg.folder())?;
 	let filter_input = types::FilterInput {
 		suite_pattern: opts.suite.clone(),

--- a/crates/surrealkit/src/tester/runner.rs
+++ b/crates/surrealkit/src/tester/runner.rs
@@ -170,8 +170,8 @@ impl RunnerContext {
 				self.cfg.ns().to_string(),
 				format!("{}_sk_test_{}_{}", self.cfg.db(), self.run_id, slug),
 			),
-			AuthLevel::Database => {
-				unreachable!("AuthLevel::Database is rejected by tester::run_test")
+			AuthLevel::Database | AuthLevel::None => {
+				unreachable!("AuthLevel::Database/None are rejected by tester::run_test")
 			}
 		};
 		let host = self.cfg.host().to_string();
@@ -713,8 +713,8 @@ async fn cleanup_suite_db(cfg: &DbCfg, host: &str, namespace: &str, database: &s
 			let resp = db.query(drop_db).await?;
 			let _ = resp.check();
 		}
-		AuthLevel::Database => {
-			unreachable!("AuthLevel::Database is rejected by tester::run_test")
+		AuthLevel::Database | AuthLevel::None => {
+			unreachable!("AuthLevel::Database/None are rejected by tester::run_test")
 		}
 	}
 	Ok(())

--- a/crates/surrealkit/tests/auth_levels.rs
+++ b/crates/surrealkit/tests/auth_levels.rs
@@ -60,6 +60,7 @@ fn make_cfg(url: &str, auth_level: AuthLevel, user: &str, pass: &str) -> DbCfg {
 					AuthLevel::Root => "root",
 					AuthLevel::Namespace => "namespace",
 					AuthLevel::Database => "database",
+					AuthLevel::None => "none",
 				}
 				.into(),
 			),

--- a/crates/surrealkit/tests/fixtures/embed_seed/widgets.surql
+++ b/crates/surrealkit/tests/fixtures/embed_seed/widgets.surql
@@ -1,0 +1,1 @@
+CREATE widget:gadget SET name = "Gadget";

--- a/crates/surrealkit/tests/macro_embed.rs
+++ b/crates/surrealkit/tests/macro_embed.rs
@@ -9,6 +9,7 @@ use surrealdb::opt::capabilities::Capabilities;
 
 // Path is relative to this crate's Cargo.toml.
 surrealkit::embed_schema!("tests/fixtures/embed_schema");
+surrealkit::embed_seed!("tests/fixtures/embed_seed");
 
 async fn mem_db() -> Surreal<Any> {
 	let cfg = Config::new().capabilities(Capabilities::all());
@@ -40,4 +41,26 @@ async fn embed_schema_sync_applies_schema() {
 		.map(|m| m.contains_key("widget"))
 		.unwrap_or(false);
 	assert!(has_widget, "embedded sync should have created the 'widget' table");
+}
+
+#[test]
+fn embed_seed_generates_seed_slice() {
+	assert!(
+		embedded_seed::SEEDS.iter().any(|f| f.sql.contains("CREATE widget:gadget")),
+		"embedded SEEDS should include the fixture file"
+	);
+}
+
+#[tokio::test]
+async fn embed_seed_runs_once_and_tracks() {
+	let db = mem_db().await;
+	embedded_seed::seed(&db).await.expect("generated seed must apply");
+	// A second run is a no-op thanks to `__seed` tracking. Without it the
+	// `CREATE widget:gadget` would fail with "already exists".
+	embedded_seed::seed(&db).await.expect("second seed run must be a tracked no-op");
+
+	let mut resp = db.query("SELECT count() FROM widget GROUP ALL").await.expect("count widget");
+	let count: Option<serde_json::Value> = resp.take(0).expect("take");
+	let n = count.and_then(|v| v["count"].as_u64()).unwrap_or(0);
+	assert_eq!(n, 1, "seed should have run exactly once");
 }


### PR DESCRIPTION
**Backward compatibility with existing SurrealKit instances**

Seed tracking is non-breaking

On the first seed run after upgrade, the new __seed table is empty, so load_seed_hashes returns nothing and every file executes — identical to the old "re-run everything" behavior. Tracking only kicks in afterward, skipping unchanged files on subsequent runs. Since the old seed already re-ran every file on every invocation, anything that survived the old tool is already re-run-safe, so there's no data regression.

__seed table is collision-free
Defined with DEFINE TABLE OVERWRITE __seed SCHEMAFULL PERMISSIONS NONE, so redefinition is idempotent, the __-prefixed name won't clash with user tables, and the SELECT ... FROM __seed can't fail because run_setup_embedded runs the DEFINE before the select in every seed path.

Two behavioral changes worth calling out in the release notes

seed now runs setup (DEFINE TABLE) first. The old seed command didn't call setup; the new one runs run_setup_embedded before seeding. For root/embedded connections this is a no-op upgrade. But running surrealkit seed against a remote instance as a low-privilege, DB-scoped user lacking DEFINE TABLE rights could now fail where it previously succeeded. Low risk (migration/seed flows typically use root), but it is the one real regression vector for existing remote setups.

Embedded endpoints now auto-skip auth. connect() auto-selects AuthLevel::None for mem://, surrealkv://, rocksdb://, file://, tikv://, etc. This grants full in-process access rather than restricting it, and fixes the prior failure of signing in against a fresh embedded datastore with no users — so it's not a functional regression. Note tikv:// is classified as embedded here, so any TiKV-backed setup that relied on enforced auth through SurrealKit will now connect unauthenticated. Overridable with --auth-level <level>.

**TL;DR**

Existing instances upgrade cleanly with no manual steps. Recommend adding a release-note line for caveat #2 (embedded/TiKV auth is now auto-skipped, overridable via --auth-level), since it's a connection-behavior change that isn't obvious from the "add embedded support" title.

## Issues

- Closes #70 
- Closes #52 