### PR TITLE
feat: Improve tester report readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -762,6 +762,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1210,6 +1221,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "endian-type"
@@ -2191,6 +2208,19 @@ dependencies = [
  "once_cell",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -4129,6 +4159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4532,6 +4568,7 @@ dependencies = [
  "clap",
  "hex",
  "inquire",
+ "insta",
  "regex",
  "reqwest 0.12.28",
  "rust_dotenv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,6 +2185,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4567,6 +4576,7 @@ dependencies = [
  "anyhow",
  "clap",
  "hex",
+ "indoc",
  "inquire",
  "insta",
  "regex",

--- a/crates/surrealkit/Cargo.toml
+++ b/crates/surrealkit/Cargo.toml
@@ -48,6 +48,7 @@ embedded = ['kv-surrealkv', 'kv-rocksdb', 'kv-mem']
 
 [dev-dependencies]
 test-case = '3'
+insta = { version = '1', features = ['json'] }
 
 [lints]
 workspace = true

--- a/crates/surrealkit/Cargo.toml
+++ b/crates/surrealkit/Cargo.toml
@@ -28,6 +28,7 @@ regex = '1'
 rustls = { version = '0.23', default-features = false, features = ['aws-lc-rs'] }
 inquire = '0.7'
 tempfile = '3'
+indoc = "2"
 
 [features]
 # The published CLI binary bundles only the in-memory engine, keeping the

--- a/crates/surrealkit/src/tester/mod.rs
+++ b/crates/surrealkit/src/tester/mod.rs
@@ -7,7 +7,7 @@ mod report;
 mod runner;
 mod types;
 
-use std::env;
+use std::{env, io};
 
 use anyhow::{Result, bail};
 use rust_dotenv::dotenv::DotEnv;
@@ -57,7 +57,9 @@ pub async fn run_test(
 		runner::RunnerContext::new(cfg, opts.clone(), loaded.global, base_url, timeout_ms, vars);
 	let report = ctx.run(suites).await?;
 
-	report::print_human_report(&report);
+	let stdout = io::stdout();
+	let mut out = stdout.lock();
+	report::print_human_report(&mut out, &report)?;
 	if let Some(path) = &opts.json_out {
 		report::write_json_report(path, &report)?;
 	}

--- a/crates/surrealkit/src/tester/report.rs
+++ b/crates/surrealkit/src/tester/report.rs
@@ -6,38 +6,54 @@ use anyhow::{Context, Result};
 use super::types::RunReport;
 
 pub fn print_human_report<W: Write>(out: &mut W, report: &RunReport) -> Result<()> {
-	writeln!(out, "Test run summary:")?;
+	let status = if report.suites_failed > 0 || report.cases_failed > 0 {
+		"FAIL"
+	} else {
+		"PASS"
+	};
+	writeln!(out, "Test run: {status} ({}ms)", report.duration_ms)?;
+	writeln!(out, "")?;
+
+	writeln!(out, "Summary")?;
 	writeln!(out, "  suites: {} total, {} failed", report.suites_total, report.suites_failed)?;
 	writeln!(
 		out,
-		"  cases: {} total, {} passed, {} failed",
+		"  cases : {} total, {} passed, {} failed",
 		report.cases_total, report.cases_passed, report.cases_failed
 	)?;
-	writeln!(out, "  duration_ms: {}", report.duration_ms)?;
 
-	for suite in &report.suites {
-		writeln!(
-			out,
-			"suite {} [{} / {}]: {} passed, {} failed",
-			suite.suite_name,
-			suite.namespace,
-			suite.database,
-			suite.cases_passed,
-			suite.cases_failed
-		)?;
-		for (index, case) in suite.cases.iter().enumerate() {
-			if case.passed {
+	if report.suites_failed > 0 {
+		writeln!(out, "")?;
+		writeln!(out, "Failures ({})", report.suites_failed)?;
+		for suite in &report.suites {
+			if suite.cases_failed == 0 {
 				continue;
 			}
-			writeln!(out, "  FAIL case #{}", index + 1)?;
-			for assertion in &case.assertions {
-				if assertion.passed {
+
+			writeln!(out, "  suite `{}`", suite.suite_name,)?;
+			writeln!(out, "    file     : {}", suite.suite_file)?;
+			writeln!(out, "    namespace: {}", suite.namespace)?;
+			writeln!(out, "    database : {}", suite.database)?;
+			writeln!(
+				out,
+				"    result   : {} passed, {} failed",
+				suite.cases_passed, suite.cases_failed
+			)?;
+			for (index, case) in suite.cases.iter().enumerate() {
+				if case.passed {
 					continue;
 				}
-				writeln!(out, "    - {} (failed)", assertion.name)?;
+				writeln!(out, "    case `{}` (#{})", case.name, index + 1)?;
+				for assertion in &case.assertions {
+					if assertion.passed {
+						continue;
+					}
+					writeln!(out, "      - `{}` (failed): {}", assertion.name, assertion.message)?;
+				}
 			}
 		}
 	}
+
 	Ok(())
 }
 
@@ -64,11 +80,11 @@ mod tests {
 		print_human_report(&mut output, &report)?;
 		let text = String::from_utf8(output)?;
 		insta::assert_snapshot!(text, @"
-		Test run summary:
+		Test run: PASS (1000ms)
+
+		Summary
 		  suites: 1 total, 0 failed
-		  cases: 1 total, 1 passed, 0 failed
-		  duration_ms: 1000
-		suite test_suite_name [test_ns / test_db]: 1 passed, 0 failed
+		  cases : 1 total, 1 passed, 0 failed
 		");
 		Ok(())
 	}
@@ -80,13 +96,20 @@ mod tests {
 		print_human_report(&mut output, &report)?;
 		let text = String::from_utf8(output)?;
 		insta::assert_snapshot!(text, @"
-		Test run summary:
-		  suites: 1 total, 0 failed
-		  cases: 1 total, 0 passed, 1 failed
-		  duration_ms: 1000
-		suite test_suite_name [test_ns / test_db]: 0 passed, 1 failed
-		  FAIL case #1
-		    - test_assertion_name (failed)
+		Test run: FAIL (1000ms)
+
+		Summary
+		  suites: 1 total, 1 failed
+		  cases : 1 total, 0 passed, 1 failed
+
+		Failures (1)
+		  suite `test_suite_name`
+		    file     : test_suite_file.yaml
+		    namespace: test_ns
+		    database : test_db
+		    result   : 0 passed, 1 failed
+		    case `test_case_name` (#1)
+		      - `test_assertion_name` (failed): assertion failed for some reasons
 		");
 		Ok(())
 	}
@@ -179,12 +202,17 @@ mod tests {
 		let cases_total = cases.len();
 		let cases_passed = cases.iter().filter(|c| c.passed).count();
 		let cases_failed = cases.iter().filter(|c| !c.passed).count();
+		let suites_failed = if cases_failed > 0 {
+			1
+		} else {
+			0
+		};
 		RunReport {
 			started_at: "2020-01-01T00:00:00Z".into(),
 			finished_at: "2020-01-01T00:00:01Z".into(),
 			duration_ms: 1000,
 			suites_total: 1,
-			suites_failed: 0,
+			suites_failed,
 			cases_total,
 			cases_passed,
 			cases_failed,

--- a/crates/surrealkit/src/tester/report.rs
+++ b/crates/surrealkit/src/tester/report.rs
@@ -1,54 +1,88 @@
 use std::path::Path;
 use std::{fs, io::Write};
 
-use anyhow::{Context, Result};
-
 use super::types::RunReport;
+use anyhow::{Context, Result};
+use indoc::writedoc;
+
+fn indent_block(s: &str) -> String {
+	s.lines().map(|line| format!("  {line}")).collect::<Vec<_>>().join("\n")
+}
 
 pub fn print_human_report<W: Write>(out: &mut W, report: &RunReport) -> Result<()> {
-	let status = if report.suites_failed > 0 || report.cases_failed > 0 {
-		"FAIL"
-	} else {
-		"PASS"
-	};
-	writeln!(out, "Test run: {status} ({}ms)", report.duration_ms)?;
-	writeln!(out, "")?;
-
-	writeln!(out, "Summary")?;
-	writeln!(out, "  suites: {} total, {} failed", report.suites_total, report.suites_failed)?;
-	writeln!(
+	let has_failure = report.suites_failed > 0 || report.cases_failed > 0;
+	writedoc!(
 		out,
-		"  cases : {} total, {} passed, {} failed",
-		report.cases_total, report.cases_passed, report.cases_failed
+		"
+		Test run: {status} ({duration_ms}ms)
+
+		Summary
+		- suites: {suites_total} total, {suites_failed} failed
+		- cases : {cases_total} total, {cases_passed} passed, {cases_failed} failed
+		",
+		status = if has_failure {
+			"FAIL"
+		} else {
+			"PASS"
+		},
+		duration_ms = report.duration_ms,
+		suites_total = report.suites_total,
+		suites_failed = report.suites_failed,
+		cases_total = report.cases_total,
+		cases_passed = report.cases_passed,
+		cases_failed = report.cases_failed
 	)?;
 
 	if report.suites_failed > 0 {
-		writeln!(out, "")?;
-		writeln!(out, "Failures ({})", report.suites_failed)?;
 		for suite in &report.suites {
 			if suite.cases_failed == 0 {
 				continue;
 			}
-
-			writeln!(out, "  suite `{}`", suite.suite_name,)?;
-			writeln!(out, "    file     : {}", suite.suite_file)?;
-			writeln!(out, "    namespace: {}", suite.namespace)?;
-			writeln!(out, "    database : {}", suite.database)?;
-			writeln!(
+			writedoc!(
 				out,
-				"    result   : {} passed, {} failed",
-				suite.cases_passed, suite.cases_failed
+				"
+
+				Suite: {suite_name}
+				- file     : {suite_file}
+				- namespace: {namespace}
+				- database : {database}
+				- result   : {cases_passed} passed, {cases_failed} failed
+				",
+				suite_name = suite.suite_name,
+				suite_file = suite.suite_file,
+				namespace = suite.namespace,
+				database = suite.database,
+				cases_passed = suite.cases_passed,
+				cases_failed = suite.cases_failed
 			)?;
+
 			for (index, case) in suite.cases.iter().enumerate() {
 				if case.passed {
 					continue;
 				}
-				writeln!(out, "    case `{}` (#{})", case.name, index + 1)?;
+				writedoc!(
+					out,
+					"
+
+					Case {n}: {case_name}
+					",
+					n = index + 1,
+					case_name = case.name
+				)?;
 				for assertion in &case.assertions {
 					if assertion.passed {
 						continue;
 					}
-					writeln!(out, "      - `{}` (failed): {}", assertion.name, assertion.message)?;
+					let header = format!("- {}", assertion.name);
+					let line_count = assertion.message.lines().count();
+					match line_count {
+						0 => writeln!(out, "{}", header)?,
+						1 => writeln!(out, "{}: {}", header, assertion.message)?,
+						_ => {
+							writeln!(out, "{}:", header)?;
+							writeln!(out, "{}", indent_block(&assertion.message))?;
+						}
+					}
 				}
 			}
 		}
@@ -83,8 +117,8 @@ mod tests {
 		Test run: PASS (1000ms)
 
 		Summary
-		  suites: 1 total, 0 failed
-		  cases : 1 total, 1 passed, 0 failed
+		- suites: 1 total, 0 failed
+		- cases : 1 total, 1 passed, 0 failed
 		");
 		Ok(())
 	}
@@ -99,17 +133,24 @@ mod tests {
 		Test run: FAIL (1000ms)
 
 		Summary
-		  suites: 1 total, 1 failed
-		  cases : 1 total, 0 passed, 1 failed
+		- suites: 1 total, 1 failed
+		- cases : 1 total, 0 passed, 1 failed
 
-		Failures (1)
-		  suite `test_suite_name`
-		    file     : test_suite_file.yaml
-		    namespace: test_ns
-		    database : test_db
-		    result   : 0 passed, 1 failed
-		    case `test_case_name` (#1)
-		      - `test_assertion_name` (failed): assertion failed for some reasons
+		Suite: test_suite_name
+		- file     : test_suite_file.yaml
+		- namespace: test_ns
+		- database : test_db
+		- result   : 0 passed, 1 failed
+
+		Case 1: test_case_name
+		- test_no_message_assertion
+		- test_short_assertion: assertion failed for some reasons
+		- test_multi_line_assertion:
+		  multi line assertion failed for some reasons
+		  second line
+		    third line
+		  
+		  fourth line
 		");
 		Ok(())
 	}
@@ -190,11 +231,32 @@ mod tests {
 			kind: "sql_expect".into(),
 			duration_ms: 1000,
 			message: None,
-			assertions: vec![AssertionReport {
-				name: "test_assertion_name".into(),
-				passed: false,
-				message: "assertion failed for some reasons".into(),
-			}],
+			assertions: vec![
+				AssertionReport {
+					name: "test_no_message_assertion".into(),
+					passed: false,
+					message: "".into(),
+				},
+				AssertionReport {
+					name: "test_short_assertion".into(),
+					passed: false,
+					message: "assertion failed for some reasons".into(),
+				},
+				AssertionReport {
+					name: "test_multi_line_assertion".into(),
+					passed: false,
+					message: indoc::indoc!(
+						"
+						multi line assertion failed for some reasons
+						second line
+						  third line
+
+						fourth line
+					"
+					)
+					.into(),
+				},
+			],
 		}])
 	}
 

--- a/crates/surrealkit/src/tester/report.rs
+++ b/crates/surrealkit/src/tester/report.rs
@@ -1,41 +1,44 @@
-use std::fs;
 use std::path::Path;
+use std::{fs, io::Write};
 
 use anyhow::{Context, Result};
 
 use super::types::RunReport;
 
-pub fn print_human_report(report: &RunReport) {
-	println!("Test run summary:");
-	println!("  suites: {} total, {} failed", report.suites_total, report.suites_failed);
-	println!(
+pub fn print_human_report<W: Write>(out: &mut W, report: &RunReport) -> Result<()> {
+	writeln!(out, "Test run summary:")?;
+	writeln!(out, "  suites: {} total, {} failed", report.suites_total, report.suites_failed)?;
+	writeln!(
+		out,
 		"  cases: {} total, {} passed, {} failed",
 		report.cases_total, report.cases_passed, report.cases_failed
-	);
-	println!("  duration_ms: {}", report.duration_ms);
+	)?;
+	writeln!(out, "  duration_ms: {}", report.duration_ms)?;
 
 	for suite in &report.suites {
-		println!(
+		writeln!(
+			out,
 			"suite {} [{} / {}]: {} passed, {} failed",
 			suite.suite_name,
 			suite.namespace,
 			suite.database,
 			suite.cases_passed,
 			suite.cases_failed
-		);
+		)?;
 		for (index, case) in suite.cases.iter().enumerate() {
 			if case.passed {
 				continue;
 			}
-			println!("  FAIL case #{}", index + 1);
+			writeln!(out, "  FAIL case #{}", index + 1)?;
 			for assertion in &case.assertions {
 				if assertion.passed {
 					continue;
 				}
-				println!("    - {} (failed)", assertion.name);
+				writeln!(out, "    - {} (failed)", assertion.name)?;
 			}
 		}
 	}
+	Ok(())
 }
 
 pub fn write_json_report(path: &Path, report: &RunReport) -> Result<()> {
@@ -51,22 +54,151 @@ pub fn write_json_report(path: &Path, report: &RunReport) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-	use crate::tester::types::RunReport;
+	use super::*;
+	use crate::tester::types::{AssertionReport, CaseReport, RunReport, SuiteReport};
+
+	#[test]
+	fn human_report_prints_summary() -> Result<()> {
+		let report = make_report_successful();
+		let mut output = Vec::new();
+		print_human_report(&mut output, &report)?;
+		let text = String::from_utf8(output)?;
+		insta::assert_snapshot!(text, @"
+		Test run summary:
+		  suites: 1 total, 0 failed
+		  cases: 1 total, 1 passed, 0 failed
+		  duration_ms: 1000
+		suite test_suite_name [test_ns / test_db]: 1 passed, 0 failed
+		");
+		Ok(())
+	}
+
+	#[test]
+	fn human_report_prints_failure() -> Result<()> {
+		let report = make_report_failure();
+		let mut output = Vec::new();
+		print_human_report(&mut output, &report)?;
+		let text = String::from_utf8(output)?;
+		insta::assert_snapshot!(text, @"
+		Test run summary:
+		  suites: 1 total, 0 failed
+		  cases: 1 total, 0 passed, 1 failed
+		  duration_ms: 1000
+		suite test_suite_name [test_ns / test_db]: 0 passed, 1 failed
+		  FAIL case #1
+		    - test_assertion_name (failed)
+		");
+		Ok(())
+	}
 
 	#[test]
 	fn json_report_is_serializable() {
-		let report = RunReport {
+		let report = make_report_successful();
+		let encoded = serde_json::to_string(&report).expect("serialization should work");
+		let decoded: serde_json::Value =
+			serde_json::from_str(&encoded).expect("deserialization should work");
+
+		insta::assert_json_snapshot!(
+			decoded,
+			@r#"
+		{
+		  "cases_failed": 0,
+		  "cases_passed": 1,
+		  "cases_total": 1,
+		  "duration_ms": 1000,
+		  "finished_at": "2020-01-01T00:00:01Z",
+		  "started_at": "2020-01-01T00:00:00Z",
+		  "suites": [
+		    {
+		      "cases": [
+		        {
+		          "assertions": [
+		            {
+		              "message": "assertion passed",
+		              "name": "test_assertion_name",
+		              "passed": true
+		            }
+		          ],
+		          "duration_ms": 1000,
+		          "kind": "sql_expect",
+		          "message": null,
+		          "name": "test_case_name",
+		          "passed": true
+		        }
+		      ],
+		      "cases_failed": 0,
+		      "cases_passed": 1,
+		      "cases_total": 1,
+		      "database": "test_db",
+		      "duration_ms": 1000,
+		      "namespace": "test_ns",
+		      "suite_file": "test_suite_file.yaml",
+		      "suite_name": "test_suite_name"
+		    }
+		  ],
+		  "suites_failed": 0,
+		  "suites_total": 1
+		}
+		"#
+		);
+	}
+
+	// ---------
+
+	fn make_report_successful() -> RunReport {
+		make_report(vec![CaseReport {
+			name: "test_case_name".into(),
+			passed: true,
+			kind: "sql_expect".into(),
+			duration_ms: 1000,
+			message: None,
+			assertions: vec![AssertionReport {
+				name: "test_assertion_name".into(),
+				passed: true,
+				message: "assertion passed".into(),
+			}],
+		}])
+	}
+
+	fn make_report_failure() -> RunReport {
+		make_report(vec![CaseReport {
+			name: "test_case_name".into(),
+			passed: false,
+			kind: "sql_expect".into(),
+			duration_ms: 1000,
+			message: None,
+			assertions: vec![AssertionReport {
+				name: "test_assertion_name".into(),
+				passed: false,
+				message: "assertion failed for some reasons".into(),
+			}],
+		}])
+	}
+
+	fn make_report(cases: Vec<CaseReport>) -> RunReport {
+		let cases_total = cases.len();
+		let cases_passed = cases.iter().filter(|c| c.passed).count();
+		let cases_failed = cases.iter().filter(|c| !c.passed).count();
+		RunReport {
 			started_at: "2020-01-01T00:00:00Z".into(),
 			finished_at: "2020-01-01T00:00:01Z".into(),
 			duration_ms: 1000,
 			suites_total: 1,
 			suites_failed: 0,
-			cases_total: 1,
-			cases_passed: 1,
-			cases_failed: 0,
-			suites: Vec::new(),
-		};
-		let encoded = serde_json::to_string(&report).expect("serialization should work");
-		assert!(encoded.contains("\"cases_total\":1"));
+			cases_total,
+			cases_passed,
+			cases_failed,
+			suites: vec![SuiteReport {
+				suite_file: "test_suite_file.yaml".into(),
+				suite_name: "test_suite_name".into(),
+				namespace: "test_ns".into(),
+				database: "test_db".into(),
+				duration_ms: 1000,
+				cases_total,
+				cases_passed,
+				cases_failed,
+				cases,
+			}],
+		}
 	}
 }


### PR DESCRIPTION
Improve human test report to identify the failing case and get more details about the assertion error.

new `print_human_report` layout:
```
Test run: FAIL (1000ms)

Summary
  suites: 1 total, 1 failed
  cases : 1 total, 0 passed, 1 failed

Failures (1)
  suite `test_suite_name`
    file     : test_suite_file.yaml
    namespace: test_ns
    database : test_db
    result   : 0 passed, 1 failed
    case `test_case_name` (#1)
      - `test_assertion_name` (failed): assertion failed for some reasons
```

- Add structured PASS/FAIL human report output with summary and detailed failure sections.
- Route report printing through a writable output stream so CLI output is lock-safe and testable.
- Add snapshot-based tests for human and JSON reports, and include `insta` as a dev dependency.