### PR TITLE
fix: examples/testing fixtures and suites

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,6 +2,11 @@ name: Integration Test
 
 on:
     push:
+        paths:
+            - "Cargo.toml"
+            - "examples/testing/**"
+            - "crates/surrealkit/src/tester/**"
+            - ".github/workflows/integration-test.yml"
 
 permissions:
     contents: read
@@ -25,33 +30,24 @@ jobs:
                 ports:
                     - 8000:8000
         steps:
-            - name: Wait for SurrealDB
-              shell: bash
-              run: |
-                  set -o pipefail
-                  for attempt in $(seq 1 30); do
-                    if curl -sf "http://127.0.0.1:8000/health" >/dev/null; then
-                      exit 0
-                    fi
-                    sleep 1
-                  done
-                  echo "SurrealDB did not become healthy in time."
-                  docker logs "${{ job.services.surrealdb.id }}" || true
-                  exit 1
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+              uses: actions/checkout@v7
+
             - name: Install Rust toolchain
-              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              uses: dtolnay/rust-toolchain@v1
               with:
                   toolchain: 1.94.0
-            - name: Install surrealkit
-              run: cargo install --path crates/surrealkit --locked
+
+            - name: Build surrealkit (debug)
+              run: cargo build --manifest-path crates/surrealkit/Cargo.toml --locked
+
             - name: Prepare test environment
               shell: bash
               run: |
-                  surrealkit init --yes
+                  ./target/debug/surrealkit init --yes
                   rm -rf database/tests
                   cp -r examples/testing database/tests
+
             - name: Run surrealkit tests
               env:
                   SURREALKIT_TEST_BASE_URL: http://127.0.0.1:8000
@@ -62,4 +58,12 @@ jobs:
                   SURREALDB_PASSWORD: ${{ env.SURREAL_PASS }}
                   SURREALDB_AUTH_LEVEL: "root"
               shell: bash
-              run: surrealkit test
+              run: ./target/debug/surrealkit test --json-out database/tests/report.json
+
+            - name: Upload integration test report
+              if: always()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: integration-test-report
+                  path: database/tests/report.json
+                  if-no-files-found: warn

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,65 @@
+name: Integration Test
+
+on:
+    push:
+
+permissions:
+    contents: read
+
+jobs:
+    integration_test:
+        name: Surrealkit integration tests
+        runs-on: ubuntu-22.04
+        timeout-minutes: 5
+        env:
+            SURREAL_USER: root
+            SURREAL_PASS: secret
+            SURREAL_PATH: memory
+            DEFAULT_NAMESPACE: test_ns
+            DEFAULT_DATABASE: test_db
+            SURREALDB_FOLDER: ${{ github.workspace }}/database
+        services:
+            surrealdb:
+                image: surrealdb/surrealdb:v3.2.0
+                command: start
+                ports:
+                    - 8000:8000
+        steps:
+            - name: Wait for SurrealDB
+              shell: bash
+              run: |
+                  set -o pipefail
+                  for attempt in $(seq 1 30); do
+                    if curl -sf "http://127.0.0.1:8000/health" >/dev/null; then
+                      exit 0
+                    fi
+                    sleep 1
+                  done
+                  echo "SurrealDB did not become healthy in time."
+                  docker logs "${{ job.services.surrealdb.id }}" || true
+                  exit 1
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+            - name: Install Rust toolchain
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.94.0
+            - name: Install surrealkit
+              run: cargo install --path crates/surrealkit --locked
+            - name: Prepare test environment
+              shell: bash
+              run: |
+                  surrealkit init --yes
+                  rm -rf database/tests
+                  cp -r examples/testing database/tests
+            - name: Run surrealkit tests
+              env:
+                  SURREALKIT_TEST_BASE_URL: http://127.0.0.1:8000
+                  SURREALDB_HOST: ws://127.0.0.1:8000
+                  SURREALDB_NAME: ${{ env.DEFAULT_DATABASE }}
+                  SURREALDB_NAMESPACE: ${{ env.DEFAULT_NAMESPACE }}
+                  SURREALDB_USER: ${{ env.SURREAL_USER }}
+                  SURREALDB_PASSWORD: ${{ env.SURREAL_PASS }}
+                  SURREALDB_AUTH_LEVEL: "root"
+              shell: bash
+              run: surrealkit test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,9 +17,9 @@ jobs:
         runs-on: ubuntu-22.04
         timeout-minutes: 5
         env:
+            SURREAL_PATH: rocksdb:/tmp/test_db.db
             SURREAL_USER: root
             SURREAL_PASS: secret
-            SURREAL_PATH: memory
             DEFAULT_NAMESPACE: test_ns
             DEFAULT_DATABASE: test_db
             SURREALDB_FOLDER: ${{ github.workspace }}/database

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -31,15 +31,23 @@ jobs:
                     - 8000:8000
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
             - name: Install Rust toolchain
-              uses: dtolnay/rust-toolchain@v1
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
               with:
                   toolchain: 1.94.0
 
             - name: Build surrealkit (debug)
-              run: cargo build --manifest-path crates/surrealkit/Cargo.toml --locked
+              env:
+                  CARGO_INCREMENTAL: 0
+                  RUSTFLAGS: "-C debuginfo=0"
+              run: |
+                cargo build \
+                    --manifest-path crates/surrealkit/Cargo.toml \
+                    --bin surrealkit \
+                    --no-default-features \
+                    --locked
 
             - name: Prepare test environment
               shell: bash
@@ -56,13 +64,12 @@ jobs:
                   SURREALDB_NAMESPACE: ${{ env.DEFAULT_NAMESPACE }}
                   SURREALDB_USER: ${{ env.SURREAL_USER }}
                   SURREALDB_PASSWORD: ${{ env.SURREAL_PASS }}
-                  SURREALDB_AUTH_LEVEL: "root"
               shell: bash
               run: ./target/debug/surrealkit test --json-out database/tests/report.json
 
             - name: Upload integration test report
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
               with:
                   name: integration-test-report
                   path: database/tests/report.json

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,19 +17,41 @@ jobs:
         runs-on: ubuntu-22.04
         timeout-minutes: 5
         env:
-            SURREAL_PATH: rocksdb:/tmp/test_db.db
-            SURREAL_USER: root
-            SURREAL_PASS: secret
-            DEFAULT_NAMESPACE: test_ns
-            DEFAULT_DATABASE: test_db
+            SURREALKIT_TEST_BASE_URL: http://127.0.0.1:8000
             SURREALDB_FOLDER: ${{ github.workspace }}/database
+            SURREALDB_HOST: ws://127.0.0.1:8000
+            SURREALDB_NAME: test_db
+            SURREALDB_NAMESPACE: test_ns
+            SURREALDB_USER: root
+            SURREALDB_PASSWORD: secret
+
         services:
             surrealdb:
                 image: surrealdb/surrealdb:v3.2.0
-                command: start
+                command: start --user root --pass secret memory
                 ports:
                     - 8000:8000
         steps:
+            - name: Verify root signin works
+              shell: bash
+              run: |
+                set -euo pipefail
+                for attempt in $(seq 1 20); do
+                    code="$(curl -sS -o /tmp/signin.json -w "%{http_code}" \
+                        -X POST "${{ env.SURREALKIT_TEST_BASE_URL }}/signin" \
+                        -H "Content-Type: application/json" \
+                        -d '{"user":"${{ env.SURREALDB_USER }}","pass":"${{ env.SURREALDB_PASSWORD }}"}' || true)"
+                    if [ "$code" = "200" ]; then
+                        echo "signin ok"
+                        exit 0
+                    fi
+                    echo "signin not ready (HTTP $code), retrying..."
+                    sleep 1
+                done
+                echo "signin failed after retries"
+                cat /tmp/signin.json || true
+                docker logs "${{ job.services.surrealdb.id }}" || true
+                exit 1
             - name: Checkout repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
@@ -57,13 +79,6 @@ jobs:
                   cp -r examples/testing database/tests
 
             - name: Run surrealkit tests
-              env:
-                  SURREALKIT_TEST_BASE_URL: http://127.0.0.1:8000
-                  SURREALDB_HOST: ws://127.0.0.1:8000
-                  SURREALDB_NAME: ${{ env.DEFAULT_DATABASE }}
-                  SURREALDB_NAMESPACE: ${{ env.DEFAULT_NAMESPACE }}
-                  SURREALDB_USER: ${{ env.SURREAL_USER }}
-                  SURREALDB_PASSWORD: ${{ env.SURREAL_PASS }}
               shell: bash
               run: ./target/debug/surrealkit test --json-out database/tests/report.json
 

--- a/crates/surrealkit/src/tester/report.rs
+++ b/crates/surrealkit/src/tester/report.rs
@@ -69,6 +69,10 @@ pub fn print_human_report<W: Write>(out: &mut W, report: &RunReport) -> Result<(
 					n = index + 1,
 					case_name = case.name
 				)?;
+				if let Some(message) = &case.message {
+					writeln!(out, "\n{}\n", message.trim())?;
+				}
+
 				for assertion in &case.assertions {
 					if assertion.passed {
 						continue;
@@ -143,6 +147,10 @@ mod tests {
 		- result   : 0 passed, 1 failed
 
 		Case 1: test_case_name
+
+		Case mutli-line
+		message with some details
+
 		- test_no_message_assertion
 		- test_short_assertion: assertion failed for some reasons
 		- test_multi_line_assertion:
@@ -230,7 +238,15 @@ mod tests {
 			passed: false,
 			kind: "sql_expect".into(),
 			duration_ms: 1000,
-			message: None,
+			message: Some(
+				indoc::indoc!(
+					"
+				Case mutli-line
+				message with some details
+				"
+				)
+				.into(),
+			),
 			assertions: vec![
 				AssertionReport {
 					name: "test_no_message_assertion".into(),

--- a/crates/surrealkit/src/tester/runner.rs
+++ b/crates/surrealkit/src/tester/runner.rs
@@ -344,7 +344,10 @@ async fn run_case(
 						spec.table, record_id, idx
 					),
 					PermissionAction::Delete => {
-						format!("DELETE {}:{};", spec.table, record_id)
+						format!(
+							"LET $before = DELETE ONLY {}:{} RETURN BEFORE; IF $before IS NONE {{ THROW 'cannot delete record' }};",
+							spec.table, record_id
+						)
 					}
 					PermissionAction::Query => rule.sql.clone().ok_or_else(|| {
 						anyhow!("permissions_matrix action=query in '{}' requires sql", case.name)

--- a/crates/surrealkit/src/tester/runner.rs
+++ b/crates/surrealkit/src/tester/runner.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use serde_json::Value;
 use surrealdb::Surreal;
 use surrealdb::engine::any::Any;
-use surrealdb_types::{SurrealValue, ToSql};
+use surrealdb_types::{RecordId, RecordIdKey, SurrealValue, uuid};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 use tokio::sync::Semaphore;
@@ -293,6 +293,147 @@ impl RunnerContext {
 	}
 }
 
+fn get_record_id(record: &surrealdb_types::Object) -> Result<RecordId> {
+	let value = record.get("id").ok_or_else(|| anyhow!("Record has no id"))?;
+	value.as_record().cloned().ok_or_else(|| anyhow!("Record id is not a record"))
+}
+
+async fn get_record(
+	db: &Surreal<Any>,
+	record_id: RecordId,
+) -> Result<Option<surrealdb_types::Object>> {
+	let mut response =
+		db.query("SELECT * FROM ONLY $record_id;").bind(("record_id", record_id)).await?.check()?;
+	let record: Option<surrealdb_types::Value> = response.take(0)?;
+	Ok(record.and_then(|x| x.as_object().cloned()))
+}
+
+async fn copy_record(
+	root_db: &Surreal<Any>,
+	record_id: RecordId,
+) -> Result<surrealdb_types::Object> {
+	let record = get_record(root_db, record_id.clone()).await?;
+	if record.is_none() {
+		bail!("Record {:?} cannot be copied", record_id);
+	}
+	let new_record_id = RecordId::new(record_id.table.clone(), RecordIdKey::rand());
+	let mut content = record.unwrap();
+	content.remove("id");
+	root_db
+		.query("CREATE $new_record_id CONTENT $content;")
+		.bind(("new_record_id", new_record_id.clone()))
+		.bind(("content", content))
+		.await?
+		.check()?;
+	match get_record(root_db, new_record_id).await? {
+		Some(record) => Ok(record),
+		None => bail!("New record was not copied"),
+	}
+}
+
+async fn assert_permission_action_create(
+	user_db: &Surreal<Any>,
+	root_db: &Surreal<Any>,
+	record_id: RecordId,
+) -> Result<()> {
+	let record = get_record(root_db, record_id.clone()).await?;
+	if record.is_none() {
+		bail!("permissions_matrix record {:?} is required to assert permissions", record_id);
+	}
+	let mut content = record.unwrap();
+	content.remove("id");
+	let new_record_id = RecordId::new(record_id.table.clone(), RecordIdKey::rand());
+
+	// assert create permission
+	user_db
+		.query("CREATE $new_record_id CONTENT $content;")
+		.bind(("new_record_id", new_record_id.clone()))
+		.bind(("content", content))
+		.await?
+		.check()?;
+
+	let record = get_record(root_db, new_record_id).await?;
+	if record.is_none() {
+		bail!("New record was not created");
+	}
+	Ok(())
+}
+
+async fn assert_permission_action_select(
+	user_db: &Surreal<Any>,
+	record_id: RecordId,
+) -> Result<()> {
+	// assert select permission
+	let record = get_record(user_db, record_id.clone()).await?;
+	if record.is_none() {
+		bail!("Record {:?} cannot be selected", record_id);
+	}
+	Ok(())
+}
+
+async fn assert_permission_action_update(
+	user_db: &Surreal<Any>,
+	root_db: &Surreal<Any>,
+	record_id: RecordId,
+) -> Result<()> {
+	root_db
+		.query(format!(
+			"DEFINE FIELD IF NOT EXISTS _marker ON {} TYPE option<string> DEFAULT NONE;",
+			record_id.table
+		))
+		.await?
+		.check()?;
+	let new_record = copy_record(root_db, record_id.clone()).await?;
+	let new_record_id = get_record_id(&new_record)?;
+	let new_marker = uuid::Uuid::new_v4().to_string();
+
+	// assert update permission
+	user_db
+		.query("UPDATE $new_record_id SET _marker = $new_marker;")
+		.bind(("new_record_id", new_record_id.clone()))
+		.bind(("new_marker", new_marker.clone()))
+		.await?
+		.check()?;
+
+	let record = get_record(root_db, new_record_id.clone()).await?;
+	let marker = record.as_ref().and_then(|r| r.get("_marker")).and_then(|m| m.as_string());
+	match marker {
+		Some(marker) if marker == &new_marker => Ok(()),
+		_ => bail!("Record {:?} cannot be updated", new_record_id),
+	}
+}
+
+async fn assert_permission_action_delete(
+	user_db: &Surreal<Any>,
+	root_db: &Surreal<Any>,
+	record_id: RecordId,
+) -> Result<()> {
+	let new_record = copy_record(root_db, record_id.clone()).await?;
+	let new_record_id = get_record_id(&new_record)?;
+
+	// assert delete permission
+	user_db
+		.query("DELETE $new_record_id;")
+		.bind(("new_record_id", new_record_id.clone()))
+		.await?
+		.check()?;
+
+	let record = get_record(root_db, new_record_id.clone()).await?;
+	if record.is_some() {
+		bail!("Record {:?} cannot be deleted", new_record_id);
+	}
+	Ok(())
+}
+
+async fn assert_permission_action_query(user_db: &Surreal<Any>, sql: &str) -> Result<()> {
+	let mut result = user_db.query(sql).await?.check()?;
+	let value: Option<surrealdb_types::Value> = result.take(0)?;
+	if value.is_none() {
+		bail!("Query {:?} returned no result", sql);
+	}
+	Ok(())
+}
+
 async fn run_case(
 	case: &crate::tester::types::CaseSpec,
 	actors: &HashMap<String, ActorSession>,
@@ -322,94 +463,26 @@ async fn run_case(
 			let actor_name = actor_name_or_default(spec.actor.as_deref());
 			let actor = require_actor(actors, actor_name)?;
 			let root = require_actor(actors, "root")?;
-			let record_id = spec.record_id.clone().unwrap_or_else(|| "perm_record".to_string());
+			let record_id_key = RecordIdKey::String(
+				spec.record_id.clone().unwrap_or_else(|| "perm_record".to_string()),
+			);
+			let record_id = RecordId::new(spec.table.clone(), record_id_key);
 
 			let mut assertions = Vec::new();
 			for (idx, rule) in spec.rules.iter().enumerate() {
+				let rec_id = record_id.clone();
 				let result = match rule.action {
 					PermissionAction::Create => {
-						let mut content = record_content(&root.db, &spec.table, &record_id).await?;
-						content.remove("id");
-						let new_record_id = format!("{}:new_{}", spec.table, record_id);
-						let action_sql =
-							format!("CREATE {} CONTENT {};", new_record_id, content.to_sql());
-						let verify_sql = format!("SELECT * FROM ONLY {};", new_record_id);
-						execute_sql_value(&actor.db, &action_sql).await?;
-						let result = execute_sql_value(&root.db, &verify_sql).await?;
-						result
-							.as_object()
-							.ok_or_else(|| {
-								anyhow!(
-									"New record with id={} expected, got {} response from query={} with user={}",
-									new_record_id,
-									result.to_string(),
-									verify_sql,
-									actor_name
-								)
-							})
-							.map(|_| ())
+						assert_permission_action_create(&actor.db, &root.db, rec_id).await
 					}
 					PermissionAction::Select => {
-						let verify_sql =
-							format!("SELECT * FROM ONLY {}:{};", spec.table, record_id);
-						let result = execute_sql_value(&actor.db, &verify_sql).await?;
-						result
-							.as_object()
-							.ok_or_else(|| {
-								anyhow!(
-									"Record with id={} expected, got {} response from query={}",
-									record_id,
-									result.to_string(),
-									verify_sql
-								)
-							})
-							.map(|_| ())
+						assert_permission_action_select(&actor.db, rec_id).await
 					}
 					PermissionAction::Update => {
-						let seed_sql = format!(
-							"DEFINE FIELD IF NOT EXISTS _marker ON {} TYPE option<string> DEFAULT NONE;",
-							spec.table
-						);
-						execute_sql_value(&root.db, &seed_sql).await?;
-
-						let new_marker = format!("updated_{}", idx);
-						let action_sql = format!(
-							"UPDATE {}:{} SET _marker = '{}';",
-							spec.table, record_id, new_marker
-						);
-						let verify_sql =
-							format!("SELECT _marker FROM ONLY {}:{};", spec.table, record_id);
-						execute_sql_value(&actor.db, &action_sql).await?;
-						let result = execute_sql_value(&root.db, &verify_sql).await?;
-						result
-							.as_object()
-							.and_then(|o| {
-								(o.get("_marker").and_then(|s| s.as_str()) == Some(&new_marker))
-									.then_some(o)
-							})
-							.ok_or_else(|| {
-								anyhow!(
-									"Updated record with _marker={} expected, got {} response from query={}",
-									new_marker,
-									result.to_string(),
-									verify_sql
-								)
-							})
-							.map(|_| ())
+						assert_permission_action_update(&actor.db, &root.db, rec_id).await
 					}
 					PermissionAction::Delete => {
-						let action_sql = format!("DELETE {}:{}", spec.table, record_id);
-						let verify_sql =
-							format!("SELECT * FROM ONLY {}:{};", spec.table, record_id);
-						execute_sql_value(&actor.db, &action_sql).await?;
-						let result = execute_sql_value(&root.db, &verify_sql).await?;
-						result.as_null().ok_or_else(|| {
-							anyhow!(
-								"expected no records, got {} response from query={}",
-								result.to_string(),
-								verify_sql
-							)
-						})
+						assert_permission_action_delete(&actor.db, &root.db, rec_id).await
 					}
 					PermissionAction::Query => {
 						let verify_sql = rule.sql.clone().ok_or_else(|| {
@@ -418,7 +491,7 @@ async fn run_case(
 								case.name
 							)
 						})?;
-						execute_sql_value(&actor.db, &verify_sql).await.map(|_| ())
+						assert_permission_action_query(&actor.db, &verify_sql).await
 					}
 				};
 
@@ -695,18 +768,6 @@ async fn execute_sql_value(db: &Surreal<Any>, sql: &str) -> Result<Value> {
 	let raw: surrealdb_types::Value = response.take(0)?;
 	let json = Value::from_value(raw).unwrap_or(Value::Null);
 	Ok(json)
-}
-
-async fn record_content(
-	db: &Surreal<Any>,
-	table: &str,
-	record_id: &str,
-) -> Result<surrealdb_types::Object> {
-	let sql = format!("SELECT * FROM ONLY {}:{};", table, record_id);
-	let mut response = db.query(&sql).await?.check()?;
-	let value: surrealdb_types::Value = response.take(0)?;
-	let map = value.as_object().ok_or_else(|| anyhow!("record is not an object: {}", sql))?.clone();
-	Ok(map)
 }
 
 async fn apply_fixture(

--- a/crates/surrealkit/src/tester/runner.rs
+++ b/crates/surrealkit/src/tester/runner.rs
@@ -326,41 +326,102 @@ async fn run_case(
 
 			let mut assertions = Vec::new();
 			for (idx, rule) in spec.rules.iter().enumerate() {
-				let seed_sql = format!(
-					"DEFINE FIELD IF NOT EXISTS _marker ON {} TYPE option<string> DEFAULT NONE;",
-					spec.table
-				);
-				execute_sql_value(&root.db, &seed_sql).await?;
-				let content = record_content(&root.db, &spec.table, &record_id).await?;
-				let sql = match rule.action {
+				let result = match rule.action {
 					PermissionAction::Create => {
-						let mut create_content = content.clone();
-						create_content.remove("id");
-						let content_sql = create_content.to_sql();
-						format!(
-							"CREATE {}:{}_create_{} CONTENT {};",
-							spec.table, record_id, idx, content_sql
-						)
+						let mut content = record_content(&root.db, &spec.table, &record_id).await?;
+						content.remove("id");
+						let new_record_id = format!("{}:new_{}", spec.table, record_id);
+						let action_sql =
+							format!("CREATE {} CONTENT {};", new_record_id, content.to_sql());
+						let verify_sql = format!("SELECT * FROM ONLY {};", new_record_id);
+						execute_sql_value(&actor.db, &action_sql).await?;
+						let result = execute_sql_value(&root.db, &verify_sql).await?;
+						result
+							.as_object()
+							.ok_or_else(|| {
+								anyhow!(
+									"New record with id={} expected, got {} response from query={} with user={}",
+									new_record_id,
+									result.to_string(),
+									verify_sql,
+									actor_name
+								)
+							})
+							.map(|_| ())
 					}
 					PermissionAction::Select => {
-						format!("SELECT * FROM {}:{};", spec.table, record_id)
+						let verify_sql =
+							format!("SELECT * FROM ONLY {}:{};", spec.table, record_id);
+						let result = execute_sql_value(&actor.db, &verify_sql).await?;
+						result
+							.as_object()
+							.ok_or_else(|| {
+								anyhow!(
+									"Record with id={} expected, got {} response from query={}",
+									record_id,
+									result.to_string(),
+									verify_sql
+								)
+							})
+							.map(|_| ())
 					}
-					PermissionAction::Update => format!(
-						"UPDATE {}:{} SET _marker = 'updated_{}';",
-						spec.table, record_id, idx
-					),
+					PermissionAction::Update => {
+						let seed_sql = format!(
+							"DEFINE FIELD IF NOT EXISTS _marker ON {} TYPE option<string> DEFAULT NONE;",
+							spec.table
+						);
+						execute_sql_value(&root.db, &seed_sql).await?;
+
+						let new_marker = format!("updated_{}", idx);
+						let action_sql = format!(
+							"UPDATE {}:{} SET _marker = '{}';",
+							spec.table, record_id, new_marker
+						);
+						let verify_sql =
+							format!("SELECT _marker FROM ONLY {}:{};", spec.table, record_id);
+						execute_sql_value(&actor.db, &action_sql).await?;
+						let result = execute_sql_value(&root.db, &verify_sql).await?;
+						result
+							.as_object()
+							.and_then(|o| {
+								(o.get("_marker").and_then(|s| s.as_str()) == Some(&new_marker))
+									.then_some(o)
+							})
+							.ok_or_else(|| {
+								anyhow!(
+									"Updated record with _marker={} expected, got {} response from query={}",
+									new_marker,
+									result.to_string(),
+									verify_sql
+								)
+							})
+							.map(|_| ())
+					}
 					PermissionAction::Delete => {
-						format!(
-							"LET $before = DELETE ONLY {}:{} RETURN BEFORE; IF $before IS NONE {{ THROW 'cannot delete record' }};",
-							spec.table, record_id
-						)
+						let action_sql = format!("DELETE {}:{}", spec.table, record_id);
+						let verify_sql =
+							format!("SELECT * FROM ONLY {}:{};", spec.table, record_id);
+						execute_sql_value(&actor.db, &action_sql).await?;
+						let result = execute_sql_value(&root.db, &verify_sql).await?;
+						result.as_null().ok_or_else(|| {
+							anyhow!(
+								"expected no records, got {} response from query={}",
+								result.to_string(),
+								verify_sql
+							)
+						})
 					}
-					PermissionAction::Query => rule.sql.clone().ok_or_else(|| {
-						anyhow!("permissions_matrix action=query in '{}' requires sql", case.name)
-					})?,
+					PermissionAction::Query => {
+						let verify_sql = rule.sql.clone().ok_or_else(|| {
+							anyhow!(
+								"permissions_matrix action=query in '{}' requires sql",
+								case.name
+							)
+						})?;
+						execute_sql_value(&actor.db, &verify_sql).await.map(|_| ())
+					}
 				};
 
-				let result = execute_sql_value(&actor.db, &sql).await;
 				let mut report = evaluate_outcome(
 					format!("rule_{}", idx + 1),
 					result,
@@ -369,7 +430,7 @@ async fn run_case(
 					None,
 				)?;
 				if !report.passed {
-					report.message = format!("{}; sql={}", report.message, sql);
+					report.message = format!("{}", report.message);
 				}
 				assertions.push(report);
 			}
@@ -588,7 +649,7 @@ fn actor_assertion_context(actor: &ActorSession) -> JsonAssertionContext {
 
 fn evaluate_outcome(
 	label: String,
-	result: Result<Value>,
+	result: Result<()>,
 	allow: bool,
 	error_contains: Option<&str>,
 	error_code: Option<&str>,

--- a/crates/surrealkit/src/tester/runner.rs
+++ b/crates/surrealkit/src/tester/runner.rs
@@ -175,15 +175,15 @@ impl RunnerContext {
 			}
 		};
 		let host = self.cfg.host().to_string();
-
+		let base_url =
+			self.base_url.as_ref().map(|url| format!("{}/api/{}/{}", url, namespace, database));
 		let actors =
 			self.prepare_suite(&suite, &host, &namespace, &database, DEFAULT_ROOT_DIR).await?;
 		let mut cases = Vec::new();
 
 		for case in &suite.spec.cases {
 			let case_start = Instant::now();
-			let case_result =
-				run_case(case, &actors, self.base_url.as_deref(), self.timeout_ms).await;
+			let case_result = run_case(case, &actors, base_url.as_deref(), self.timeout_ms).await;
 
 			let report = match case_result {
 				Ok(mut report) => {

--- a/crates/surrealkit/src/tester/runner.rs
+++ b/crates/surrealkit/src/tester/runner.rs
@@ -336,113 +336,174 @@ async fn copy_record(
 	}
 }
 
+async fn add_marker_field(db: &Surreal<Any>, table: &str) -> Result<()> {
+	db.query(format!(
+		"DEFINE FIELD IF NOT EXISTS _marker ON {} TYPE option<string> DEFAULT NONE;",
+		table
+	))
+	.await?
+	.check()?;
+	Ok(())
+}
+
+type AssertionResult = Result<(), AssertionError>;
+
+enum AssertionError {
+	PermissionThrow(String),
+	PermissionFailed(String),
+	InternalError(anyhow::Error),
+}
+
+impl AssertionError {
+	fn failed<E: std::fmt::Display>(error: E) -> Self {
+		Self::PermissionFailed(format!("{error}"))
+	}
+
+	fn throw<E: std::fmt::Display>(error: E) -> Self {
+		Self::PermissionThrow(format!("{error}"))
+	}
+}
+
+impl From<anyhow::Error> for AssertionError {
+	fn from(error: anyhow::Error) -> Self {
+		AssertionError::InternalError(error)
+	}
+}
+
+impl From<surrealdb::Error> for AssertionError {
+	fn from(error: surrealdb::Error) -> Self {
+		AssertionError::InternalError(anyhow::Error::from(error))
+	}
+}
+
+impl std::fmt::Display for AssertionError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			AssertionError::PermissionThrow(error) => write!(f, "permission throw: {error}"),
+			AssertionError::PermissionFailed(error) => write!(f, "permission failed: {error}"),
+			AssertionError::InternalError(error) => write!(f, "internal error: {error}"),
+		}
+	}
+}
+
 async fn assert_permission_action_create(
 	user_db: &Surreal<Any>,
 	root_db: &Surreal<Any>,
 	record_id: RecordId,
-) -> Result<()> {
+) -> AssertionResult {
 	let record = get_record(root_db, record_id.clone()).await?;
-	if record.is_none() {
-		bail!("permissions_matrix record {:?} is required to assert permissions", record_id);
-	}
-	let mut content = record.unwrap();
+	let mut content = match record {
+		Some(record) => record,
+		None => {
+			return Err(AssertionError::throw(anyhow!(
+				"permissions_matrix record {:?} is required to assert permissions",
+				record_id
+			)));
+		}
+	};
 	content.remove("id");
 	let tmp_record_id = RecordId::new(record_id.table.clone(), RecordIdKey::rand());
 
 	// assert create permission
-	user_db
+	let create_result = user_db
 		.query("CREATE $tmp_record_id CONTENT $content;")
 		.bind(("tmp_record_id", tmp_record_id.clone()))
 		.bind(("content", content))
 		.await?
-		.check()?;
+		.check()
+		.map_err(AssertionError::throw);
 
 	let record = get_record(root_db, tmp_record_id.clone()).await?;
-	if record.is_none() {
-		bail!("New record was not created");
-	} else {
-		delete_record(root_db, tmp_record_id).await?;
+	if record.is_some() {
+		delete_record(root_db, tmp_record_id.clone()).await?;
 	}
-	Ok(())
+	create_result?;
+	match record {
+		None => Err(AssertionError::failed("New record was not created")),
+		Some(..) => Ok(()),
+	}
 }
 
 async fn assert_permission_action_select(
 	user_db: &Surreal<Any>,
 	record_id: RecordId,
-) -> Result<()> {
+) -> AssertionResult {
 	// assert select permission
-	let record = get_record(user_db, record_id.clone()).await?;
-	if record.is_none() {
-		bail!("Record {:?} cannot be selected", record_id);
+	let result = user_db
+		.query("SELECT * FROM ONLY $record_id;")
+		.bind(("record_id", record_id))
+		.await?
+		.check();
+
+	match result {
+		Err(err) => Err(AssertionError::throw(err)),
+		Ok(mut records) => match records.take::<Option<surrealdb_types::Value>>(0) {
+			Ok(Some(..)) => Ok(()),
+			_ => Err(AssertionError::failed("Record cannot be selected")),
+		},
 	}
-	Ok(())
 }
 
 async fn assert_permission_action_update(
 	user_db: &Surreal<Any>,
 	root_db: &Surreal<Any>,
 	record_id: RecordId,
-) -> Result<()> {
-	root_db
-		.query(format!(
-			"DEFINE FIELD IF NOT EXISTS _marker ON {} TYPE option<string> DEFAULT NONE;",
-			record_id.table
-		))
-		.await?
-		.check()?;
+) -> AssertionResult {
+	add_marker_field(root_db, &record_id.table).await?;
 	let tmp_record = copy_record(root_db, record_id.clone()).await?;
 	let tmp_record_id = get_record_id(&tmp_record)?;
 	let new_marker = uuid::Uuid::new_v4().to_string();
 
 	// assert update permission
-	user_db
+	let update_result = user_db
 		.query("UPDATE $tmp_record_id SET _marker = $new_marker;")
 		.bind(("tmp_record_id", tmp_record_id.clone()))
 		.bind(("new_marker", new_marker.clone()))
 		.await?
-		.check()?;
+		.check()
+		.map_err(AssertionError::throw);
 
 	let record = get_record(root_db, tmp_record_id.clone()).await?;
 	let marker = record.as_ref().and_then(|r| r.get("_marker")).and_then(|m| m.as_string());
 	if record.is_some() {
 		delete_record(root_db, tmp_record_id.clone()).await?;
 	}
-	return match marker {
+	update_result?;
+	match marker {
 		Some(marker) if marker == &new_marker => Ok(()),
-		_ => bail!("Record {:?} cannot be updated", tmp_record_id),
-	};
+		_ => Err(AssertionError::failed("Record cannot be updated")),
+	}
 }
 
 async fn assert_permission_action_delete(
 	user_db: &Surreal<Any>,
 	root_db: &Surreal<Any>,
 	record_id: RecordId,
-) -> Result<()> {
+) -> AssertionResult {
 	let tmp_record = copy_record(root_db, record_id.clone()).await?;
 	let tmp_record_id = get_record_id(&tmp_record)?;
 
 	// assert delete permission
-	user_db
+	let delete_result = user_db
 		.query("DELETE $tmp_record_id;")
 		.bind(("tmp_record_id", tmp_record_id.clone()))
 		.await?
-		.check()?;
+		.check()
+		.map_err(AssertionError::throw);
 
 	let record = get_record(root_db, tmp_record_id.clone()).await?;
 	if record.is_some() {
 		delete_record(root_db, tmp_record_id.clone()).await?;
-		bail!("Record {:?} cannot be deleted", tmp_record_id);
 	}
-	Ok(())
+	delete_result?;
+	match record {
+		None => Ok(()),
+		Some(..) => Err(AssertionError::failed("Record cannot be deleted")),
+	}
 }
 
-async fn assert_permission_action_query(user_db: &Surreal<Any>, sql: &str) -> Result<()> {
-	let mut result = user_db.query(sql).await?.check()?;
-	let value: Option<surrealdb_types::Value> = result.take(0)?;
-	if value.is_none() {
-		bail!("Query {:?} returned no result", sql);
-	}
-	Ok(())
+async fn assert_permission_action_query(user_db: &Surreal<Any>, sql: &str) -> AssertionResult {
+	user_db.query(sql).await?.check().map(|_| ()).map_err(AssertionError::throw)
 }
 
 async fn run_case(
@@ -506,8 +567,12 @@ async fn run_case(
 					}
 				};
 
+				if let Err(AssertionError::InternalError(error)) = result {
+					return Err(error);
+				}
+
 				let mut report = evaluate_outcome(
-					format!("rule_{}", idx + 1),
+					format!("action:{} (#{})", rule.action.label(), idx + 1),
 					result,
 					rule.allow,
 					rule.error_contains.as_deref(),
@@ -733,7 +798,7 @@ fn actor_assertion_context(actor: &ActorSession) -> JsonAssertionContext {
 
 fn evaluate_outcome(
 	label: String,
-	result: Result<()>,
+	result: AssertionResult,
 	allow: bool,
 	error_contains: Option<&str>,
 	error_code: Option<&str>,

--- a/crates/surrealkit/src/tester/runner.rs
+++ b/crates/surrealkit/src/tester/runner.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use serde_json::Value;
 use surrealdb::Surreal;
 use surrealdb::engine::any::Any;
-use surrealdb_types::SurrealValue;
+use surrealdb_types::{SurrealValue, ToSql};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 use tokio::sync::Semaphore;
@@ -327,20 +327,26 @@ async fn run_case(
 			let mut assertions = Vec::new();
 			for (idx, rule) in spec.rules.iter().enumerate() {
 				let seed_sql = format!(
-					"UPSERT {}:{} MERGE {{ __surrealkit_perm_seed: true }};",
-					spec.table, record_id
+					"DEFINE FIELD IF NOT EXISTS _marker ON {} TYPE option<string> DEFAULT NONE;",
+					spec.table
 				);
-				let _ = execute_sql_value(&root.db, &seed_sql).await;
+				execute_sql_value(&root.db, &seed_sql).await?;
+				let content = record_content(&root.db, &spec.table, &record_id).await?;
 				let sql = match rule.action {
-					PermissionAction::Create => format!(
-						"CREATE {}:{}_create_{} CONTENT {{ marker: 'perm' }};",
-						spec.table, record_id, idx
-					),
+					PermissionAction::Create => {
+						let mut create_content = content.clone();
+						create_content.remove("id");
+						let content_sql = create_content.to_sql();
+						format!(
+							"CREATE {}:{}_create_{} CONTENT {};",
+							spec.table, record_id, idx, content_sql
+						)
+					}
 					PermissionAction::Select => {
 						format!("SELECT * FROM {}:{};", spec.table, record_id)
 					}
 					PermissionAction::Update => format!(
-						"UPDATE {}:{} SET marker = 'updated_{}';",
+						"UPDATE {}:{} SET _marker = 'updated_{}';",
 						spec.table, record_id, idx
 					),
 					PermissionAction::Delete => {
@@ -628,6 +634,18 @@ async fn execute_sql_value(db: &Surreal<Any>, sql: &str) -> Result<Value> {
 	let raw: surrealdb_types::Value = response.take(0)?;
 	let json = Value::from_value(raw).unwrap_or(Value::Null);
 	Ok(json)
+}
+
+async fn record_content(
+	db: &Surreal<Any>,
+	table: &str,
+	record_id: &str,
+) -> Result<surrealdb_types::Object> {
+	let sql = format!("SELECT * FROM ONLY {}:{};", table, record_id);
+	let mut response = db.query(&sql).await?.check()?;
+	let value: surrealdb_types::Value = response.take(0)?;
+	let map = value.as_object().ok_or_else(|| anyhow!("record is not an object: {}", sql))?.clone();
+	Ok(map)
 }
 
 async fn apply_fixture(

--- a/crates/surrealkit/src/tester/runner.rs
+++ b/crates/surrealkit/src/tester/runner.rs
@@ -308,6 +308,11 @@ async fn get_record(
 	Ok(record.and_then(|x| x.as_object().cloned()))
 }
 
+async fn delete_record(db: &Surreal<Any>, record_id: RecordId) -> Result<()> {
+	db.query("DELETE $record_id;").bind(("record_id", record_id)).await?.check()?;
+	Ok(())
+}
+
 async fn copy_record(
 	root_db: &Surreal<Any>,
 	record_id: RecordId,
@@ -316,16 +321,16 @@ async fn copy_record(
 	if record.is_none() {
 		bail!("Record {:?} cannot be copied", record_id);
 	}
-	let new_record_id = RecordId::new(record_id.table.clone(), RecordIdKey::rand());
+	let tmp_record_id = RecordId::new(record_id.table.clone(), RecordIdKey::rand());
 	let mut content = record.unwrap();
 	content.remove("id");
 	root_db
-		.query("CREATE $new_record_id CONTENT $content;")
-		.bind(("new_record_id", new_record_id.clone()))
+		.query("CREATE $tmp_record_id CONTENT $content;")
+		.bind(("tmp_record_id", tmp_record_id.clone()))
 		.bind(("content", content))
 		.await?
 		.check()?;
-	match get_record(root_db, new_record_id).await? {
+	match get_record(root_db, tmp_record_id).await? {
 		Some(record) => Ok(record),
 		None => bail!("New record was not copied"),
 	}
@@ -342,19 +347,21 @@ async fn assert_permission_action_create(
 	}
 	let mut content = record.unwrap();
 	content.remove("id");
-	let new_record_id = RecordId::new(record_id.table.clone(), RecordIdKey::rand());
+	let tmp_record_id = RecordId::new(record_id.table.clone(), RecordIdKey::rand());
 
 	// assert create permission
 	user_db
-		.query("CREATE $new_record_id CONTENT $content;")
-		.bind(("new_record_id", new_record_id.clone()))
+		.query("CREATE $tmp_record_id CONTENT $content;")
+		.bind(("tmp_record_id", tmp_record_id.clone()))
 		.bind(("content", content))
 		.await?
 		.check()?;
 
-	let record = get_record(root_db, new_record_id).await?;
+	let record = get_record(root_db, tmp_record_id.clone()).await?;
 	if record.is_none() {
 		bail!("New record was not created");
+	} else {
+		delete_record(root_db, tmp_record_id).await?;
 	}
 	Ok(())
 }
@@ -383,24 +390,27 @@ async fn assert_permission_action_update(
 		))
 		.await?
 		.check()?;
-	let new_record = copy_record(root_db, record_id.clone()).await?;
-	let new_record_id = get_record_id(&new_record)?;
+	let tmp_record = copy_record(root_db, record_id.clone()).await?;
+	let tmp_record_id = get_record_id(&tmp_record)?;
 	let new_marker = uuid::Uuid::new_v4().to_string();
 
 	// assert update permission
 	user_db
-		.query("UPDATE $new_record_id SET _marker = $new_marker;")
-		.bind(("new_record_id", new_record_id.clone()))
+		.query("UPDATE $tmp_record_id SET _marker = $new_marker;")
+		.bind(("tmp_record_id", tmp_record_id.clone()))
 		.bind(("new_marker", new_marker.clone()))
 		.await?
 		.check()?;
 
-	let record = get_record(root_db, new_record_id.clone()).await?;
+	let record = get_record(root_db, tmp_record_id.clone()).await?;
 	let marker = record.as_ref().and_then(|r| r.get("_marker")).and_then(|m| m.as_string());
-	match marker {
-		Some(marker) if marker == &new_marker => Ok(()),
-		_ => bail!("Record {:?} cannot be updated", new_record_id),
+	if record.is_some() {
+		delete_record(root_db, tmp_record_id.clone()).await?;
 	}
+	return match marker {
+		Some(marker) if marker == &new_marker => Ok(()),
+		_ => bail!("Record {:?} cannot be updated", tmp_record_id),
+	};
 }
 
 async fn assert_permission_action_delete(
@@ -408,19 +418,20 @@ async fn assert_permission_action_delete(
 	root_db: &Surreal<Any>,
 	record_id: RecordId,
 ) -> Result<()> {
-	let new_record = copy_record(root_db, record_id.clone()).await?;
-	let new_record_id = get_record_id(&new_record)?;
+	let tmp_record = copy_record(root_db, record_id.clone()).await?;
+	let tmp_record_id = get_record_id(&tmp_record)?;
 
 	// assert delete permission
 	user_db
-		.query("DELETE $new_record_id;")
-		.bind(("new_record_id", new_record_id.clone()))
+		.query("DELETE $tmp_record_id;")
+		.bind(("tmp_record_id", tmp_record_id.clone()))
 		.await?
 		.check()?;
 
-	let record = get_record(root_db, new_record_id.clone()).await?;
+	let record = get_record(root_db, tmp_record_id.clone()).await?;
 	if record.is_some() {
-		bail!("Record {:?} cannot be deleted", new_record_id);
+		delete_record(root_db, tmp_record_id.clone()).await?;
+		bail!("Record {:?} cannot be deleted", tmp_record_id);
 	}
 	Ok(())
 }

--- a/crates/surrealkit/src/tester/types.rs
+++ b/crates/surrealkit/src/tester/types.rs
@@ -168,6 +168,18 @@ pub enum PermissionAction {
 	Query,
 }
 
+impl PermissionAction {
+	pub fn label(&self) -> &'static str {
+		match self {
+			Self::Create => "create",
+			Self::Select => "select",
+			Self::Update => "update",
+			Self::Delete => "delete",
+			Self::Query => "query",
+		}
+	}
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SchemaMetadataCase {

--- a/examples/testing/config.toml
+++ b/examples/testing/config.toml
@@ -14,5 +14,13 @@ kind = "root"
 [actors.access_user]
 kind = "record"
 access = "app_access"
-signup_params = { email = "viewer@example.com", password = "viewer-password" }
+signup_params = { email = "viewer@example.com", password = "viewer-password", read_only = false }
 signin_params = { email = "viewer@example.com", password = "viewer-password" }
+
+
+# Record access actor authenticated through DEFINE ACCESS app_access.
+[actors.readonly_user]
+kind = "record"
+access = "app_access"
+signup_params = { email = "readonly@example.com", password = "readonly-password", read_only = true }
+signin_params = { email = "readonly@example.com", password = "readonly-password" }

--- a/examples/testing/fixtures/root_and_access_setup.surql
+++ b/examples/testing/fixtures/root_and_access_setup.surql
@@ -1,7 +1,7 @@
 DEFINE TABLE OVERWRITE customer SCHEMAFULL
 	PERMISSIONS
 		FOR select WHERE $auth != NONE,
-		FOR create, update WHERE $auth != NONE,
+		FOR create, update WHERE !$auth.read_only,
 		FOR delete NONE;
 
 DEFINE FIELD OVERWRITE name ON customer TYPE string;
@@ -19,12 +19,14 @@ DEFINE TABLE OVERWRITE app_user SCHEMAFULL
 
 DEFINE FIELD OVERWRITE email ON app_user TYPE string;
 DEFINE FIELD OVERWRITE pass ON app_user TYPE string;
+DEFINE FIELD OVERWRITE read_only ON app_user TYPE bool DEFAULT true;
 DEFINE INDEX OVERWRITE app_user_email_unique ON TABLE app_user FIELDS email UNIQUE;
 
 DEFINE ACCESS app_access ON DATABASE TYPE RECORD
 	SIGNUP (
 		CREATE app_user CONTENT {
 			email: $email,
+			read_only: $read_only,
 			pass: crypto::argon2::generate($password)
 		}
 	)

--- a/examples/testing/fixtures/root_and_access_setup.surql
+++ b/examples/testing/fixtures/root_and_access_setup.surql
@@ -10,6 +10,8 @@ DEFINE FIELD OVERWRITE joined_at ON customer TYPE datetime;
 DEFINE FIELD OVERWRITE created_at ON customer TYPE datetime DEFAULT time::now();
 DEFINE FIELD OVERWRITE tier ON customer TYPE string VALUE IF age >= 18 THEN "adult" ELSE "minor" END;
 
+CREATE customer:alice CONTENT { name: 'Alice', age: 12, joined_at: <datetime>'2025-01-10T00:00:00Z' };
+
 DEFINE TABLE OVERWRITE app_user SCHEMAFULL
 	PERMISSIONS
 		FOR select, create, update WHERE true,

--- a/examples/testing/fixtures/root_and_access_setup.surql
+++ b/examples/testing/fixtures/root_and_access_setup.surql
@@ -44,4 +44,15 @@ DEFINE FUNCTION OVERWRITE fn::format_customer($name: string, $age: number) {
 	RETURN string::concat($name, "#", <string>$age);
 };
 
-DEFINE API "/v1";
+DEFINE API "/test"
+	FOR get
+		MIDDLEWARE
+			api::res::body("json")
+		THEN {
+			{
+				status: 200,
+				body: {
+					result: "OK"
+				}
+			}
+		}

--- a/examples/testing/fixtures/root_and_access_setup.surql
+++ b/examples/testing/fixtures/root_and_access_setup.surql
@@ -12,6 +12,15 @@ DEFINE FIELD OVERWRITE tier ON customer TYPE string VALUE IF age >= 18 THEN "adu
 
 CREATE customer:alice CONTENT { name: 'Alice', age: 12, joined_at: <datetime>'2025-01-10T00:00:00Z' };
 
+
+DEFINE TABLE OVERWRITE customer_read_only SCHEMAFULL
+	PERMISSIONS
+		FOR select WHERE $auth != NONE,
+		FOR create, update, delete WHERE THROW "Read-only customer";
+DEFINE FIELD OVERWRITE name ON customer_read_only TYPE string;
+CREATE customer_read_only:bob CONTENT { name: 'Bob' };
+
+
 DEFINE TABLE OVERWRITE app_user SCHEMAFULL
 	PERMISSIONS
 		FOR select, create, update WHERE true,

--- a/examples/testing/fixtures/root_and_access_setup.surql
+++ b/examples/testing/fixtures/root_and_access_setup.surql
@@ -44,4 +44,4 @@ DEFINE FUNCTION OVERWRITE fn::format_customer($name: string, $age: number) {
 	RETURN string::concat($name, "#", <string>$age);
 };
 
-DEFINE API v1;
+DEFINE API "/v1";

--- a/examples/testing/suites/root_access_full_stack.toml
+++ b/examples/testing/suites/root_access_full_stack.toml
@@ -12,29 +12,16 @@ contains = ["customer", "fn::format_customer", "/test"]
 name = "root_can_create_customer_with_string_number_date_and_computed"
 kind = "schema_behavior"
 actor = "root"
-action_sql = "CREATE customer:alpha CONTENT { name: 'Alice', age: 27, joined_at: <datetime>'2025-01-15T00:00:00Z' };"
+action_sql = "CREATE customer:alpha CONTENT { name: 'Alpha', age: 27, joined_at: <datetime>'2025-01-15T00:00:00Z' };"
 verify_sql = "SELECT name, age, joined_at, tier, created_at FROM customer:alpha;"
 expect_success = true
-
-[[cases.assertions]]
-path = "0.name"
-equals = "Alice"
-
-[[cases.assertions]]
-path = "0.age"
-equals = 27
-
-[[cases.assertions]]
-path = "0.joined_at"
-contains = "2025-01-15"
-
-[[cases.assertions]]
-path = "0.tier"
-equals = "adult"
-
-[[cases.assertions]]
-path = "0.created_at"
-exists = true
+assertions = [
+  { path = "0.name", equals = "Alpha" },
+  { path = "0.age", equals = 27 },
+  { path = "0.joined_at", contains = "2025-01-15" },
+  { path = "0.tier", equals = "adult" },
+  { path = "0.created_at", exists = true },
+]
 
 [[cases]]
 name = "type_validation_rejects_invalid_number"
@@ -50,10 +37,9 @@ kind = "sql_expect"
 actor = "root"
 sql = "RETURN fn::format_customer('Alice', 27);"
 allow = true
-
-[[cases.assertions]]
-path = ""
-equals = "Alice#27"
+assertions = [
+  { path = ".", equals = "Alice#27" },
+]
 
 [[cases]]
 name = "root_can_create_graph_edge"
@@ -66,18 +52,23 @@ setup_sql = [
 action_sql = "RELATE person:alice->follows->person:bob CONTENT { since: <datetime>'2024-01-01T00:00:00Z' };"
 verify_sql = "SELECT out, in, since FROM follows WHERE out = person:alice AND in = person:bob;"
 expect_success = true
+assertions = [
+  { path = "0.out", contains = "person:alice" },
+  { path = "0.in", contains = "person:bob" },
+  { path = "0.since", contains = "2024-01-01" },
+]
 
-[[cases.assertions]]
-path = "0.out"
-contains = "person:alice"
+# Access user tests
 
-[[cases.assertions]]
-path = "0.in"
-contains = "person:bob"
-
-[[cases.assertions]]
-path = "0.since"
-contains = "2024-01-01"
+[[cases]]
+name = "access_user_is_not_read_only"
+kind = "sql_expect"
+actor = "access_user"
+sql = "RETURN $auth.read_only"
+allow = true
+assertions = [
+    { path = ".", equals = false }
+]
 
 [[cases]]
 name = "access_user_permissions_matrix"
@@ -85,29 +76,57 @@ kind = "permissions_matrix"
 actor = "access_user"
 table = "customer"
 record_id = "alice"
-
-[[cases.rules]]
-action = "create"
-allow = true
-
-[[cases.rules]]
-action = "select"
-allow = true
-
-[[cases.rules]]
-action = "update"
-allow = true
-
-[[cases.rules]]
-action = "delete"
-allow = false
+rules = [
+  { action = "create", allow = true },
+  { action = "select", allow = true },
+  { action = "update", allow = true },
+  { action = "delete", allow = false },
+]
 
 [[cases]]
 name = "access_user_cannot_delete_customer"
-kind = "sql_expect"
+kind = "schema_behavior"
 actor = "access_user"
-sql = "LET $before = DELETE ONLY customer:alpha RETURN BEFORE; IF $before IS NONE { THROW 'cannot delete record' };"
-allow = false
+action_sql = "DELETE customer:alice;"
+verify_sql = "SELECT id FROM ONLY customer:alice;"
+assertions = [
+  { path = ".id", equals = "customer:alice" },
+]
+
+# Readonly user tests
+
+[[cases]]
+name = "readonly_user_is_read_only"
+kind = "sql_expect"
+actor = "readonly_user"
+sql = "RETURN $auth.read_only"
+allow = true
+assertions = [
+    { path = ".", equals = true }
+]
+
+[[cases]]
+name = "readonly_user_permissions_matrix"
+kind = "permissions_matrix"
+actor = "readonly_user"
+table = "customer"
+record_id = "alice"
+rules = [
+  { action = "select", allow = true },
+  { action = "create", allow = false },
+  { action = "update", allow = false },
+  { action = "delete", allow = false },
+]
+
+[[cases]]
+name = "readonly_user_cannot_delete_customer"
+kind = "schema_behavior"
+actor = "readonly_user"
+action_sql = "DELETE customer:alice;"
+verify_sql = "SELECT id FROM ONLY customer:alice;"
+assertions = [
+  { path = ".id", equals = "customer:alice" },
+]
 
 # API routes are examples: adjust path/status to match your SurrealDB API surface.
 [[cases]]

--- a/examples/testing/suites/root_access_full_stack.toml
+++ b/examples/testing/suites/root_access_full_stack.toml
@@ -80,8 +80,23 @@ rules = [
   { action = "create", allow = true },
   { action = "select", allow = true },
   { action = "update", allow = true },
-  { action = "delete", allow = false },
+  { action = "delete", allow = false, error_contains = "permission failed" },
 ]
+
+[[cases]]
+name = "access_user_permissions_matrix_permission_throws"
+kind = "permissions_matrix"
+actor = "access_user"
+table = "customer_read_only"
+record_id = "bob"
+rules = [
+  { action = "create", allow = false, error_contains = "Read-only customer" },
+  { action = "select", allow = true },
+  { action = "update", allow = false, error_contains = "Read-only customer" },
+  { action = "delete", allow = false, error_contains = "Read-only customer" }
+]
+
+
 
 [[cases]]
 name = "access_user_cannot_delete_customer"

--- a/examples/testing/suites/root_access_full_stack.toml
+++ b/examples/testing/suites/root_access_full_stack.toml
@@ -109,25 +109,33 @@ error_contains = "permission"
 
 # API routes are examples: adjust path/status to match your SurrealDB API surface.
 [[cases]]
-name = "root_api_health_example"
+name = "root_api_example"
 kind = "api_request"
 actor = "root"
 method = "GET"
-path = "/api/v1/health"
+path = "/test"
 expected_status = 200
 
 [[cases.header_assertions]]
 name = "content-type"
 exists = true
 
+[[cases.body_assertions]]
+path = ".result"
+equals = "OK"
+
 [[cases]]
-name = "access_user_api_profile_example"
+name = "access_user_api_example"
 kind = "api_request"
 actor = "access_user"
 method = "GET"
-path = "/api/v1/profile"
+path = "/test"
 expected_status = 200
 
 [[cases.header_assertions]]
 name = "content-type"
 exists = true
+
+[[cases.body_assertions]]
+path = ".result"
+equals = "OK"

--- a/examples/testing/suites/root_access_full_stack.toml
+++ b/examples/testing/suites/root_access_full_stack.toml
@@ -87,6 +87,10 @@ table = "customer"
 record_id = "alpha"
 
 [[cases.rules]]
+action = "create"
+allow = true
+
+[[cases.rules]]
 action = "select"
 allow = true
 

--- a/examples/testing/suites/root_access_full_stack.toml
+++ b/examples/testing/suites/root_access_full_stack.toml
@@ -6,7 +6,7 @@ name = "metadata_contains_table_function_api"
 kind = "schema_metadata"
 actor = "root"
 sql = "INFO FOR DB;"
-contains = ["customer", "fn::format_customer", "v1"]
+contains = ["customer", "fn::format_customer", "/test"]
 
 [[cases]]
 name = "root_can_create_customer_with_string_number_date_and_computed"
@@ -97,15 +97,13 @@ allow = true
 [[cases.rules]]
 action = "delete"
 allow = false
-error_contains = "permission"
 
 [[cases]]
 name = "access_user_cannot_delete_customer"
 kind = "sql_expect"
 actor = "access_user"
-sql = "DELETE customer:alpha;"
+sql = "LET $before = DELETE ONLY customer:alpha RETURN BEFORE; IF $before IS NONE { THROW 'cannot delete record' };"
 allow = false
-error_contains = "permission"
 
 # API routes are examples: adjust path/status to match your SurrealDB API surface.
 [[cases]]

--- a/examples/testing/suites/root_access_full_stack.toml
+++ b/examples/testing/suites/root_access_full_stack.toml
@@ -84,7 +84,7 @@ name = "access_user_permissions_matrix"
 kind = "permissions_matrix"
 actor = "access_user"
 table = "customer"
-record_id = "alpha"
+record_id = "alice"
 
 [[cases.rules]]
 action = "create"


### PR DESCRIPTION
### `api_request` suite

- `DEFINE API "/endpoint"` must starts with a slash
- The base-url must contain the namespace and database in the URL path.
- There's no `profile` or `health` endpoint produced by default for API defined with `DEFINE API...`

### `permissions_matrix` suite

- `DELETE` on an non-existing entry or if user doesn't have delete permission is not producing error
- `UPDATE` can't create new fields like `marker` in `SCHEMAFULL` table 