### PR TITLE
Fix/tester missing header assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "376186e025eb294c22f06236b23417608f1867def159c3a61a5c57788a3e889e"
+checksum = "421c6cf955c6cb1451d36c8a3740ab2a22880265d0fa93d8ea22cbc425c90479"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1063,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b70289db1b66826fa1ef2b4113bf2f9d0dedc8df983b2b804c38dc1e519e15e"
+checksum = "7cdf7d491910fbff13338e07460c9197a3c172268cfd4d8f8e69e5cec5a256d9"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62c9d81aad6e3df6a026b1bb693dbbcfbee5ea93d9e7a5ff15c31576263bc29"
+checksum = "de1643bbece645f03527ef120bc7dd5e4e40557980dbe52ee51129adfb58a851"
 dependencies = [
  "cfg-if",
  "diskann-wide",
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fcacef8ea9274969f98499456718f3dcaa5d3d7392b3171079653370fa0b20"
+checksum = "421f02c42e57a2153dc65b66b4b95fe2be56e14bf9f95253b663abcac8521166"
 dependencies = [
  "cfg-if",
  "half",
@@ -1227,12 +1227,6 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
-name = "endian-type"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "equivalent"
@@ -2634,15 +2628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "noisy_float"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,17 +3314,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "radix_trie"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
-dependencies = [
- "endian-type",
- "nibble_vec",
- "serde",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,9 +3543,9 @@ dependencies = [
 
 [[package]]
 name = "revision"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e735a8c2864f0b0fd48a55d0a71c081c7cbef8c8958a4665d8de423f20f2d0cf"
+checksum = "13b48b66c1cd4bf814516ea48f727d4b3697e3fa8841be99a7d9cbb8c9ac1666"
 dependencies = [
  "bytes",
  "chrono",
@@ -3585,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "revision-derive"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f446f8c55ba240992330b09f69fe9e5ec8a2e1ba266843cb9f59d7bc6037c821"
+checksum = "3d266d798eaaa2921e14188dfe998bb7cc0528ec26e894b4be0e35fe2b19c89d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4320,9 +4294,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "3.1.5"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ee3110fe3ab8172eb8c135c96ed2d57c7470cdf1ad732d176db95a92c9faab"
+checksum = "01fef5cc04dd6cb042391d48c0f78a586c56042e999f8cb17f0b97b0a147e2c0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4358,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-collections"
-version = "3.1.5"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069e0c90dad71cf8f17475f75118a56ad3047f2f46fac24643e562b415b3f11a"
+checksum = "ca3472955f9692427583e78476d5b03c6f750bf11dc8a04383e0d365d7bd5d99"
 dependencies = [
  "revision",
  "storekey",
@@ -4368,9 +4342,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.1.5"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9780c2f3dd6a3cb1cce8ca7c866b5e82ac4377b826a09bf718ca441bfd2bd747"
+checksum = "8cd76c36f8b545a9371eec050bb2ae83750a6f60bae8c6d92d06956943348f4c"
 dependencies = [
  "addr",
  "affinitypool",
@@ -4422,7 +4396,6 @@ dependencies = [
  "phf 0.13.1",
  "pin-project-lite",
  "quick_cache",
- "radix_trie",
  "rand 0.9.4",
  "rand_core 0.6.4",
  "rayon",
@@ -4517,9 +4490,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-strand"
-version = "3.1.5"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af300a172983b23c05e692cacba462ca023e3e9404812b6783d09a8af487865"
+checksum = "a86f53e307b6b8275b15eaff2b718add63605cb804395d156589770c3bf38e56"
 dependencies = [
  "revision",
  "serde",
@@ -4528,9 +4501,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types"
-version = "3.1.5"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd434d643c040c2872c9cfc88c90e9910e9a55456d2df7e68e92725225d3e20"
+checksum = "e0d70c7f4dbf1198521282a171a03f2f77f38a1225a149f7c0175e758f773b8a"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4559,9 +4532,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.1.5"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d385184f3b727c58c4d099a877a4c54ffe879dd190396cc80b1676146b8b2b"
+checksum = "dc11310bfc0ae3e546cd14788f8d36e7616dbe41fa68b4b265b29fea34a7d7e1"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ license = 'Apache-2.0'
 
 [workspace.dependencies]
 surrealkit-macros = { path = 'crates/surrealkit-macros', version = '1.0.0-beta.1' }
-surrealdb = { version = '3.1.5', features = ['protocol-http', 'jwks'] }
-surrealdb-types = { version = '3.1.5' }
+surrealdb = { version = '3.2.4', features = ['protocol-http', 'jwks'] }
+surrealdb-types = { version = '3.2.4' }
 anyhow = '1'
 serde = { version = '1.0.225', features = ['derive'] }
 serde_json = '1.0'

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -121,6 +121,39 @@ Targets are applied one at a time and there is no cross-database transaction, so
 a failing run can leave some targets applied and others not. Every operation is
 idempotent, so re-running after a fix is safe.
 
+## If you use the tester
+
+### Missing paths and headers now fail instead of passing
+
+Through 0.7, an assertion on a JSON path or response header that did **not exist**
+silently passed. The check compared "not found" against an unset `exists` field and
+matched, so the `equals` / `contains` / `regex` comparison was never reached:
+
+```toml
+[[cases.assertions]]
+path = "0.owner"     # typo, or a query that matched zero rows
+equals = "user:alice"
+```
+
+On 0.7 that reported a pass. On 1.0 it fails with `path '0.owner' not found`. The same
+applies to `header_assertions` against a header the response never sent.
+
+**If assertions go red on upgrade, they were most likely never being evaluated.** Check
+the actual shape of the result before assuming SurrealKit regressed — in this repository
+the change surfaced an example suite whose `RELATE` verify query had `in` and `out`
+swapped, matched zero rows, and had been green for the whole 0.7 line.
+
+To assert that something is genuinely absent, say so explicitly:
+
+```toml
+[[cases.assertions]]
+path = "0.secret"
+exists = false
+```
+
+`exists = false` is the only way to pass on a missing path or header; there is no
+suite-level opt-out, and unknown keys in an assertion are rejected at parse time.
+
 ## If you use the Rust library
 
 ### `Rollout` no longer writes to disk

--- a/README.md
+++ b/README.md
@@ -670,6 +670,12 @@ path = "0.id"
 exists = true
 ```
 
+An assertion whose `path` (or `header_assertions` `name`) is not present in the result
+**fails** with `path '<path>' not found`. This catches typos and queries that matched
+zero rows, which would otherwise report a pass without ever running the comparison. To
+assert that a field is genuinely absent, state it explicitly with `exists = false` —
+that is the only spec that passes on a missing path.
+
 To compare a returned field against the authenticated actor, use `equals_auth` with `$auth` or `$auth.<property>`:
 
 ```toml

--- a/crates/surrealkit/src/tester/assertions.rs
+++ b/crates/surrealkit/src/tester/assertions.rs
@@ -146,7 +146,7 @@ pub fn assert_header_value(
 	if found.is_none() {
 		return Ok(AssertionReport {
 			name: label,
-			passed: exists == assertion.exists.unwrap_or(false),
+			passed: assertion.exists == Some(false),
 			message: format!("header '{}' not found", assertion.name),
 		});
 	}
@@ -381,5 +381,78 @@ mod tests {
 		let report =
 			assert_json_value_with_context(&actual, &assertion, 0, &ctx).expect("assertion ok");
 		assert!(report.passed, "{}", report.message);
+	}
+
+	fn header_map(pairs: &[(&str, &str)]) -> reqwest::header::HeaderMap {
+		use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+
+		let mut headers = HeaderMap::new();
+		for (name, value) in pairs {
+			headers.insert(
+				HeaderName::from_bytes(name.as_bytes()).expect("valid header name"),
+				HeaderValue::from_str(value).expect("valid header value"),
+			);
+		}
+		headers
+	}
+
+	#[test]
+	fn missing_header_fails_by_default() {
+		let headers = header_map(&[("content-type", "application/json")]);
+		let assertion = HeaderAssertionSpec {
+			name: "x-missing".to_string(),
+			exists: None,
+			equals: Some("acme".to_string()),
+			contains: None,
+			regex: None,
+		};
+
+		let report =
+			assert_header_value(&headers, &assertion, 0).expect("assertion should evaluate");
+
+		assert!(!report.passed);
+		assert_eq!(report.message, "header 'x-missing' not found");
+	}
+
+	#[test]
+	fn missing_header_can_be_asserted_explicitly() {
+		let headers = header_map(&[("content-type", "application/json")]);
+		let assertion = HeaderAssertionSpec {
+			name: "x-missing".to_string(),
+			exists: Some(false),
+			equals: None,
+			contains: None,
+			regex: None,
+		};
+
+		let report =
+			assert_header_value(&headers, &assertion, 0).expect("assertion should evaluate");
+
+		assert!(report.passed, "{}", report.message);
+	}
+
+	#[test]
+	fn present_header_match_and_mismatch_are_unchanged() {
+		let headers = header_map(&[("content-type", "application/json")]);
+		let matching = HeaderAssertionSpec {
+			name: "content-type".to_string(),
+			exists: None,
+			equals: Some("application/json".to_string()),
+			contains: None,
+			regex: None,
+		};
+		let mismatching = HeaderAssertionSpec {
+			equals: Some("text/plain".to_string()),
+			..matching.clone()
+		};
+
+		let matched = assert_header_value(&headers, &matching, 0)
+			.expect("matching assertion should evaluate");
+		let mismatched = assert_header_value(&headers, &mismatching, 1)
+			.expect("mismatching assertion should evaluate");
+
+		assert!(matched.passed, "{}", matched.message);
+		assert!(!mismatched.passed);
+		assert!(mismatched.message.contains("expected 'text/plain' got 'application/json'"));
 	}
 }


### PR DESCRIPTION
An assertion whose `path` (or `header_assertions` `name`) is not present in the result
**fails** with `path '<path>' not found`. This catches typos and queries that matched
zero rows, which would otherwise report a pass without ever running the comparison. To
assert that a field is genuinely absent, state it explicitly with `exists = false` -
that is the only spec that passes on a missing path.
